### PR TITLE
Fix index when inserting a structure into an array

### DIFF
--- a/src/zcl_ajson.clas.abap
+++ b/src/zcl_ajson.clas.abap
@@ -216,6 +216,7 @@ CLASS ZCL_AJSON IMPLEMENTATION.
           path = lv_cur_path
           name = lv_cur_name.
       if sy-subrc <> 0. " New node, assume it is always object as it has a named child, use touch_array to init array
+        clear node_tmp.
         if node_parent is not initial. " if has parent
           node_parent->children = node_parent->children + 1.
           if node_parent->type = 'array'.

--- a/src/zcl_ajson.clas.testclasses.abap
+++ b/src/zcl_ajson.clas.testclasses.abap
@@ -1412,6 +1412,7 @@ class ltcl_writer_test definition final
     methods set_int for testing raising zcx_ajson_error.
     methods set_date for testing raising zcx_ajson_error.
     methods read_only for testing raising zcx_ajson_error.
+    methods set_array_obj for testing raising zcx_ajson_error.
 
 endclass.
 
@@ -2176,6 +2177,47 @@ class ltcl_writer_test implementation.
       cl_abap_unit_assert=>fail( ).
     catch zcx_ajson_error.
     endtry.
+
+  endmethod.
+
+  method set_array_obj.
+
+    data lo_cut type ref to zcl_ajson.
+    data nodes_exp type ref to lcl_nodes_helper.
+    data li_writer type ref to zif_ajson_writer.
+
+    create object nodes_exp.
+    nodes_exp->add( '                 |         |object |                        |  |1' ).
+    nodes_exp->add( '/                |issues   |array  |                        |  |2' ).
+    nodes_exp->add( '/issues/         |1        |object |                        |1 |1' ).
+    nodes_exp->add( '/issues/         |2        |object |                        |2 |1' ).
+    nodes_exp->add( '/issues/1/       |end      |object |                        |  |2' ).
+    nodes_exp->add( '/issues/1/end/   |col      |num    |26                      |  |0' ).
+    nodes_exp->add( '/issues/1/end/   |row      |num    |4                       |  |0' ).
+    nodes_exp->add( '/issues/2/       |end      |object |                        |  |2' ).
+    nodes_exp->add( '/issues/2/end/   |col      |num    |22                      |  |0' ).
+    nodes_exp->add( '/issues/2/end/   |row      |num    |3                       |  |0' ).
+
+    lo_cut = zcl_ajson=>create_empty( ).
+    li_writer = lo_cut.
+
+    li_writer->touch_array( iv_path = '/issues' ).
+    li_writer->set(
+      iv_path = '/issues/1/end/col'
+      iv_val  = 26 ).
+    li_writer->set(
+      iv_path = '/issues/1/end/row'
+      iv_val  = 4 ).
+    li_writer->set(
+      iv_path = '/issues/2/end/col'
+      iv_val  = 22 ).
+    li_writer->set(
+      iv_path = '/issues/2/end/row'
+      iv_val  = 3 ).
+
+    cl_abap_unit_assert=>assert_equals(
+      act = lo_cut->mt_json_tree
+      exp = nodes_exp->sorted( ) ).
 
   endmethod.
 


### PR DESCRIPTION
When inserting a structure inside an array, the index for 'object' should be zero. See test case 

Without the fix you get
```
/issues/1/       |end      |object |                        |1|2
/issues/2/       |end      |object |                        |2|2
```
But it should be
```
/issues/1/       |end      |object |                        |0|2
/issues/2/       |end      |object |                        |0|2
```