### PR TITLE
zif_ajson

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 ![abaplint](https://github.com/sbcgua/ajson/workflows/abaplint/badge.svg)
-![abap package version](https://img.shields.io/endpoint?url=https://shield.abap.space/version-shield-json/github/sbcgua/ajson/src/zcl_ajson.clas.abap)
+![abap package version](https://img.shields.io/endpoint?url=https://shield.abap.space/version-shield-json/github/sbcgua/ajson/src/zif_ajson.clas.abap)
 
 # abap json (ajson)
 
@@ -20,6 +20,8 @@ Installed using [abapGit](https://github.com/larshp/abapGit)
 The class `zcl_ajson` implements 2 interfaces:
 - `zif_ajson_reader` - used to access items of the json data
 - `zif_ajson_writer` - used to set items of the json data
+
+Since v1.0.4 it also implements `zif_ajson` which unites all the types, constants in methods in one interface. This very probably will become the recommended approach to use ajson. Reader and writer may be potentially deprecated (not decided yet), follow the updates.
 
 ### Instantiating and basics
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -8,6 +8,10 @@ Legend
 + : added
 - : removed
 
+v1.0.4, 2021-??
+------------------
+! BREAKING: Move types, constants to zif_ajson, also alias methods of reader/writer
+
 v1.0.3, 2021-01-09
 ------------------
 A stable version before interface changes !

--- a/src/zcl_ajson.clas.locals_imp.abap
+++ b/src/zcl_ajson.clas.locals_imp.abap
@@ -14,7 +14,7 @@ class lcl_utils definition final.
       importing
         iv_path type string
       returning
-        value(rv_path_name) type zcl_ajson=>ty_path_name.
+        value(rv_path_name) type zif_ajson=>ty_path_name.
     class-methods validate_array_index
       importing
         iv_path type string
@@ -95,14 +95,14 @@ class lcl_json_parser definition final.
       importing
         iv_json type string
       returning
-        value(rt_json_tree) type zcl_ajson=>ty_nodes_tt
+        value(rt_json_tree) type zif_ajson=>ty_nodes_tt
       raising
         zcx_ajson_error.
 
   private section.
 
     types:
-      ty_stack_tt type standard table of ref to zcl_ajson=>ty_node.
+      ty_stack_tt type standard table of ref to zif_ajson=>ty_node.
 
     data mt_stack type ty_stack_tt.
 
@@ -122,7 +122,7 @@ class lcl_json_parser definition final.
       importing
         iv_json type string
       returning
-        value(rt_json_tree) type zcl_ajson=>ty_nodes_tt
+        value(rt_json_tree) type zif_ajson=>ty_nodes_tt
       raising
         zcx_ajson_error cx_sxml_error.
 
@@ -249,7 +249,7 @@ class lcl_json_serializer definition final create private.
 
     class-methods stringify
       importing
-        it_json_tree type zcl_ajson=>ty_nodes_ts
+        it_json_tree type zif_ajson=>ty_nodes_ts
         iv_indent type i default 0
       returning
         value(rv_json_string) type string
@@ -262,7 +262,7 @@ class lcl_json_serializer definition final create private.
 
     class-data gv_comma_with_lf type string.
 
-    data mt_json_tree type zcl_ajson=>ty_nodes_ts.
+    data mt_json_tree type zif_ajson=>ty_nodes_ts.
     data mt_buffer type string_table.
     data mv_indent_step type i.
     data mv_level type i.
@@ -281,7 +281,7 @@ class lcl_json_serializer definition final create private.
 
     methods stringify_node
       importing
-        is_node type zcl_ajson=>ty_node
+        is_node type zif_ajson=>ty_node
       raising
         zcx_ajson_error.
 
@@ -346,15 +346,15 @@ class lcl_json_serializer implementation.
     endif.
 
     case is_node-type.
-      when zcl_ajson=>node_type-array.
+      when zif_ajson=>node_type-array.
         lv_item = lv_item && '['.
-      when zcl_ajson=>node_type-object.
+      when zif_ajson=>node_type-object.
         lv_item = lv_item && '{'.
-      when zcl_ajson=>node_type-string.
+      when zif_ajson=>node_type-string.
         lv_item = lv_item && |"{ escape( is_node-value ) }"|.
-      when zcl_ajson=>node_type-boolean or zcl_ajson=>node_type-number.
+      when zif_ajson=>node_type-boolean or zif_ajson=>node_type-number.
         lv_item = lv_item && is_node-value.
-      when zcl_ajson=>node_type-null.
+      when zif_ajson=>node_type-null.
         lv_item = lv_item && 'null'.
       when others.
         zcx_ajson_error=>raise(
@@ -363,7 +363,7 @@ class lcl_json_serializer implementation.
     endcase.
 
     if mv_indent_step > 0
-      and ( is_node-type = zcl_ajson=>node_type-array or is_node-type = zcl_ajson=>node_type-object )
+      and ( is_node-type = zif_ajson=>node_type-array or is_node-type = zif_ajson=>node_type-object )
       and is_node-children > 0.
       mv_level = mv_level + 1.
       lv_item = lv_item && cl_abap_char_utilities=>newline.
@@ -373,21 +373,21 @@ class lcl_json_serializer implementation.
 
     " finish complex item
 
-    if is_node-type = zcl_ajson=>node_type-array or is_node-type = zcl_ajson=>node_type-object.
+    if is_node-type = zif_ajson=>node_type-array or is_node-type = zif_ajson=>node_type-object.
       data lv_children_path type string.
       data lv_tail type string.
 
       lv_children_path = is_node-path && is_node-name && '/'. " for root: path = '' and name = '', so result is '/'
 
       case is_node-type.
-        when zcl_ajson=>node_type-array.
+        when zif_ajson=>node_type-array.
           if is_node-children > 0.
             stringify_set(
               iv_parent_path = lv_children_path
               iv_array       = abap_true ).
           endif.
           lv_tail = ']'.
-        when zcl_ajson=>node_type-object.
+        when zif_ajson=>node_type-object.
           if is_node-children > 0.
             stringify_set(
               iv_parent_path = lv_children_path
@@ -497,7 +497,7 @@ class lcl_json_to_abap definition final.
 
     methods to_abap
       importing
-        it_nodes type zcl_ajson=>ty_nodes_ts
+        it_nodes type zif_ajson=>ty_nodes_ts
       raising
         zcx_ajson_error.
 
@@ -531,13 +531,13 @@ class lcl_json_to_abap implementation.
         describe field <value> type lv_type.
 
         case <n>-type.
-          when zcl_ajson=>node_type-null.
+          when zif_ajson=>node_type-null.
             " Do nothing
-          when zcl_ajson=>node_type-boolean.
+          when zif_ajson=>node_type-boolean.
             <value> = boolc( <n>-value = 'true' ).
-          when zcl_ajson=>node_type-number.
+          when zif_ajson=>node_type-number.
             <value> = <n>-value.
-          when zcl_ajson=>node_type-string.
+          when zif_ajson=>node_type-string.
             if lv_type = 'D' and <n>-value is not initial.
               data lv_y type c length 4.
               data lv_m type c length 2.
@@ -555,13 +555,13 @@ class lcl_json_to_abap implementation.
             else.
               <value> = <n>-value.
             endif.
-          when zcl_ajson=>node_type-object.
+          when zif_ajson=>node_type-object.
             if not lv_type co 'uv'.
               zcx_ajson_error=>raise(
                 iv_msg      = 'Expected structure'
                 iv_location = <n>-path && <n>-name ).
             endif.
-          when zcl_ajson=>node_type-array.
+          when zif_ajson=>node_type-array.
             if not lv_type co 'h'.
               zcx_ajson_error=>raise(
                 iv_msg      = 'Expected table'
@@ -667,10 +667,10 @@ class lcl_abap_to_json definition final.
     class-methods convert
       importing
         iv_data type any
-        is_prefix type zcl_ajson=>ty_path_name optional
+        is_prefix type zif_ajson=>ty_path_name optional
         iv_array_index type i default 0
       returning
-        value(rt_nodes) type zcl_ajson=>ty_nodes_tt
+        value(rt_nodes) type zif_ajson=>ty_nodes_tt
       raising
         zcx_ajson_error.
 
@@ -678,10 +678,10 @@ class lcl_abap_to_json definition final.
       importing
         iv_data type any
         iv_type type string
-        is_prefix type zcl_ajson=>ty_path_name optional
+        is_prefix type zif_ajson=>ty_path_name optional
         iv_array_index type i default 0
       returning
-        value(rt_nodes) type zcl_ajson=>ty_nodes_tt
+        value(rt_nodes) type zif_ajson=>ty_nodes_tt
       raising
         zcx_ajson_error.
 
@@ -695,29 +695,29 @@ class lcl_abap_to_json definition final.
       importing
         iv_data type any
         io_type type ref to cl_abap_typedescr
-        is_prefix type zcl_ajson=>ty_path_name
+        is_prefix type zif_ajson=>ty_path_name
         iv_index type i default 0
       changing
-        ct_nodes type zcl_ajson=>ty_nodes_tt
+        ct_nodes type zif_ajson=>ty_nodes_tt
       raising
         zcx_ajson_error.
 
     methods convert_ajson
       importing
         io_json type ref to zcl_ajson
-        is_prefix type zcl_ajson=>ty_path_name
+        is_prefix type zif_ajson=>ty_path_name
         iv_index type i default 0
       changing
-        ct_nodes type zcl_ajson=>ty_nodes_tt.
+        ct_nodes type zif_ajson=>ty_nodes_tt.
 
     methods convert_value
       importing
         iv_data type any
         io_type type ref to cl_abap_typedescr
-        is_prefix type zcl_ajson=>ty_path_name
+        is_prefix type zif_ajson=>ty_path_name
         iv_index type i default 0
       changing
-        ct_nodes type zcl_ajson=>ty_nodes_tt
+        ct_nodes type zif_ajson=>ty_nodes_tt
       raising
         zcx_ajson_error.
 
@@ -725,10 +725,10 @@ class lcl_abap_to_json definition final.
       importing
         iv_data type any
         io_type type ref to cl_abap_typedescr
-        is_prefix type zcl_ajson=>ty_path_name
+        is_prefix type zif_ajson=>ty_path_name
         iv_index type i default 0
       changing
-        ct_nodes type zcl_ajson=>ty_nodes_tt
+        ct_nodes type zif_ajson=>ty_nodes_tt
       raising
         zcx_ajson_error.
 
@@ -736,11 +736,11 @@ class lcl_abap_to_json definition final.
       importing
         iv_data type any
         io_type type ref to cl_abap_typedescr
-        is_prefix type zcl_ajson=>ty_path_name
+        is_prefix type zif_ajson=>ty_path_name
         iv_index type i default 0
       changing
-        ct_nodes type zcl_ajson=>ty_nodes_tt
-        cs_root  type zcl_ajson=>ty_node optional
+        ct_nodes type zif_ajson=>ty_nodes_tt
+        cs_root  type zif_ajson=>ty_node optional
       raising
         zcx_ajson_error.
 
@@ -748,10 +748,10 @@ class lcl_abap_to_json definition final.
       importing
         iv_data type any
         io_type type ref to cl_abap_typedescr
-        is_prefix type zcl_ajson=>ty_path_name
+        is_prefix type zif_ajson=>ty_path_name
         iv_index type i default 0
       changing
-        ct_nodes type zcl_ajson=>ty_nodes_tt
+        ct_nodes type zif_ajson=>ty_nodes_tt
       raising
         zcx_ajson_error.
 
@@ -760,10 +760,10 @@ class lcl_abap_to_json definition final.
         iv_data type any
         iv_type type string
         io_type type ref to cl_abap_typedescr
-        is_prefix type zcl_ajson=>ty_path_name
+        is_prefix type zif_ajson=>ty_path_name
         iv_index type i default 0
       changing
-        ct_nodes type zcl_ajson=>ty_nodes_tt
+        ct_nodes type zif_ajson=>ty_nodes_tt
       raising
         zcx_ajson_error.
 
@@ -891,17 +891,17 @@ class lcl_abap_to_json implementation.
     <n>-index = iv_index.
 
     if io_type->absolute_name = '\TYPE-POOL=ABAP\TYPE=ABAP_BOOL' or io_type->absolute_name = '\TYPE=XFELD'.
-      <n>-type = zcl_ajson=>node_type-boolean.
+      <n>-type = zif_ajson=>node_type-boolean.
       if iv_data is not initial.
         <n>-value = 'true'.
       else.
         <n>-value = 'false'.
       endif.
     elseif io_type->type_kind co 'CNgXyDT'. " Char like, date/time, xstring
-      <n>-type = zcl_ajson=>node_type-string.
+      <n>-type = zif_ajson=>node_type-string.
       <n>-value = |{ iv_data }|.
     elseif io_type->type_kind co 'bsI8PaeF'. " Numeric
-      <n>-type = zcl_ajson=>node_type-number.
+      <n>-type = zif_ajson=>node_type-number.
       <n>-value = |{ iv_data }|.
     else.
       zcx_ajson_error=>raise( |Unexpected elemetary type [{
@@ -921,7 +921,7 @@ class lcl_abap_to_json implementation.
     <n>-index = iv_index.
 
     if iv_data is initial.
-      <n>-type  = zcl_ajson=>node_type-null.
+      <n>-type  = zif_ajson=>node_type-null.
       <n>-value = 'null'.
     else.
       " TODO support data references
@@ -953,7 +953,7 @@ class lcl_abap_to_json implementation.
       append initial line to ct_nodes assigning <root>.
       <root>-path  = is_prefix-path.
       <root>-name  = is_prefix-name.
-      <root>-type  = zcl_ajson=>node_type-object.
+      <root>-type  = zif_ajson=>node_type-object.
       <root>-index = iv_index.
     endif.
 
@@ -1009,7 +1009,7 @@ class lcl_abap_to_json implementation.
     append initial line to ct_nodes assigning <root>.
     <root>-path  = is_prefix-path.
     <root>-name  = is_prefix-name.
-    <root>-type  = zcl_ajson=>node_type-array.
+    <root>-type  = zif_ajson=>node_type-array.
     <root>-index = iv_index.
 
     ls_next_prefix-path = is_prefix-path && is_prefix-name && '/'.
@@ -1060,18 +1060,18 @@ class lcl_abap_to_json implementation.
 
     lv_prefix = is_prefix-path && is_prefix-name.
     if io_type->type_kind co 'CNgXyDT'. " Char like, date/time, xstring
-      if iv_type = zcl_ajson=>node_type-boolean and iv_data <> 'true' and iv_data <> 'false'.
+      if iv_type = zif_ajson=>node_type-boolean and iv_data <> 'true' and iv_data <> 'false'.
         zcx_ajson_error=>raise( |Unexpected boolean value [{ iv_data }] @{ lv_prefix }| ).
-      elseif iv_type = zcl_ajson=>node_type-null and iv_data is not initial.
+      elseif iv_type = zif_ajson=>node_type-null and iv_data is not initial.
         zcx_ajson_error=>raise( |Unexpected null value [{ iv_data }] @{ lv_prefix }| ).
-      elseif iv_type = zcl_ajson=>node_type-number and iv_data cn '0123456789. E+-'.
+      elseif iv_type = zif_ajson=>node_type-number and iv_data cn '0123456789. E+-'.
         zcx_ajson_error=>raise( |Unexpected numeric value [{ iv_data }] @{ lv_prefix }| ).
-      elseif iv_type <> zcl_ajson=>node_type-string and iv_type <> zcl_ajson=>node_type-boolean
-        and iv_type <> zcl_ajson=>node_type-null and iv_type <> zcl_ajson=>node_type-number.
+      elseif iv_type <> zif_ajson=>node_type-string and iv_type <> zif_ajson=>node_type-boolean
+        and iv_type <> zif_ajson=>node_type-null and iv_type <> zif_ajson=>node_type-number.
         zcx_ajson_error=>raise( |Unexpected type for value [{ iv_type },{ iv_data }] @{ lv_prefix }| ).
       endif.
     elseif io_type->type_kind co 'bsI8PaeF'. " Numeric
-      if iv_type <> zcl_ajson=>node_type-number.
+      if iv_type <> zif_ajson=>node_type-number.
         zcx_ajson_error=>raise( |Unexpected value for numeric [{ iv_data }] @{ lv_prefix }| ).
       endif.
     else.

--- a/src/zcl_ajson.clas.testclasses.abap
+++ b/src/zcl_ajson.clas.testclasses.abap
@@ -6,13 +6,13 @@
 class lcl_nodes_helper definition final.
   public section.
 
-    data mt_nodes type zcl_ajson=>ty_nodes_tt.
+    data mt_nodes type zif_ajson=>ty_nodes_tt.
     methods add
       importing
         iv_str type string.
     methods sorted
       returning
-        value(rt_nodes) type zcl_ajson=>ty_nodes_ts.
+        value(rt_nodes) type zif_ajson=>ty_nodes_ts.
 
 endclass.
 
@@ -119,7 +119,7 @@ class ltcl_parser_test implementation.
   method parse.
 
     data lo_cut type ref to lcl_json_parser.
-    data lt_act type zcl_ajson=>ty_nodes_tt.
+    data lt_act type zif_ajson=>ty_nodes_tt.
     data lo_nodes type ref to lcl_nodes_helper.
 
     create object lo_nodes.
@@ -189,7 +189,7 @@ class ltcl_serializer_test definition final
         value(rv_json) type string.
     class-methods sample_nodes
       returning
-        value(rt_nodes) type zcl_ajson=>ty_nodes_ts.
+        value(rt_nodes) type zif_ajson=>ty_nodes_ts.
 
   private section.
 
@@ -552,7 +552,7 @@ class ltcl_utils_test implementation.
 
   method split_path.
 
-    data ls_exp type zcl_ajson=>ty_path_name.
+    data ls_exp type zif_ajson=>ty_path_name.
     data lv_path type string.
 
     lv_path     = ''. " alias to root
@@ -2290,7 +2290,7 @@ class ltcl_writer_test implementation.
 
     data lv_path type string.
 
-    field-symbols <node> type zcl_ajson=>ty_node.
+    field-symbols <node> type zif_ajson=>ty_node.
 
     loop at io_json_in->mt_json_tree assigning <node> where path = iv_path.
       lv_path = <node>-path && <node>-name && '/'.
@@ -2597,7 +2597,7 @@ class ltcl_abap_to_json implementation.
     lo_nodes->add( '/a/b/   |c     |object |     ||0' ).
     lo_src->mt_json_tree = lo_nodes->mt_nodes.
 
-    data lt_nodes type zcl_ajson=>ty_nodes_tt.
+    data lt_nodes type zif_ajson=>ty_nodes_tt.
     lt_nodes = lcl_abap_to_json=>convert( iv_data = lo_src ).
 
     cl_abap_unit_assert=>assert_equals(
@@ -2609,7 +2609,7 @@ class ltcl_abap_to_json implementation.
   method set_value.
 
     data lo_nodes_exp type ref to lcl_nodes_helper.
-    data lt_nodes type zcl_ajson=>ty_nodes_tt.
+    data lt_nodes type zif_ajson=>ty_nodes_tt.
 
     " number
     create object lo_nodes_exp.
@@ -2668,7 +2668,7 @@ class ltcl_abap_to_json implementation.
   method set_null.
 
     data lo_nodes_exp type ref to lcl_nodes_helper.
-    data lt_nodes type zcl_ajson=>ty_nodes_tt.
+    data lt_nodes type zif_ajson=>ty_nodes_tt.
     data lv_null_ref type ref to data.
 
     " null
@@ -2686,8 +2686,8 @@ class ltcl_abap_to_json implementation.
   method prefix.
 
     data lo_nodes_exp type ref to lcl_nodes_helper.
-    data lt_nodes type zcl_ajson=>ty_nodes_tt.
-    data ls_prefix type zcl_ajson=>ty_path_name.
+    data lt_nodes type zif_ajson=>ty_nodes_tt.
+    data ls_prefix type zif_ajson=>ty_path_name.
 
     ls_prefix-path = '/a/'.
     ls_prefix-name = 'b'.
@@ -2708,7 +2708,7 @@ class ltcl_abap_to_json implementation.
 
     data lo_nodes_exp type ref to lcl_nodes_helper.
     data ls_struc type ty_struc.
-    data lt_nodes type zcl_ajson=>ty_nodes_tt.
+    data lt_nodes type zif_ajson=>ty_nodes_tt.
 
     ls_struc-a = 'abc'.
     ls_struc-b = 10.
@@ -2734,7 +2734,7 @@ class ltcl_abap_to_json implementation.
 
     data lo_nodes_exp type ref to lcl_nodes_helper.
     data ls_struc type ty_struc_complex.
-    data lt_nodes type zcl_ajson=>ty_nodes_tt.
+    data lt_nodes type zif_ajson=>ty_nodes_tt.
     field-symbols <i> like line of ls_struc-tab.
 
     ls_struc-a = 'abc'.
@@ -2794,7 +2794,7 @@ class ltcl_abap_to_json implementation.
   method set_array.
 
     data lo_nodes_exp type ref to lcl_nodes_helper.
-    data lt_nodes type zcl_ajson=>ty_nodes_tt.
+    data lt_nodes type zif_ajson=>ty_nodes_tt.
 
     data lt_tab type table of ty_struc.
     field-symbols <s> like line of lt_tab.

--- a/src/zcl_ajson_utilities.clas.abap
+++ b/src/zcl_ajson_utilities.clas.abap
@@ -53,12 +53,12 @@ ENDCLASS.
 
 
 
-CLASS zcl_ajson_utilities IMPLEMENTATION.
+CLASS ZCL_AJSON_UTILITIES IMPLEMENTATION.
 
 
   method delete_empty_nodes.
 
-    data ls_json_tree type zcl_ajson=>ty_node.
+    data ls_json_tree like line of io_json->mt_json_tree.
     data lv_subrc type sy-subrc.
 
     do.
@@ -134,8 +134,8 @@ CLASS zcl_ajson_utilities IMPLEMENTATION.
       lv_path_b type string.
 
     field-symbols:
-      <node_a> type zcl_ajson=>ty_node,
-      <node_b> type zcl_ajson=>ty_node.
+      <node_a> like line of mo_json_a->mt_json_tree,
+      <node_b> like line of mo_json_a->mt_json_tree.
 
     loop at mo_json_a->mt_json_tree assigning <node_a> where path = iv_path.
       lv_path_a = <node_a>-path && <node_a>-name && '/'.
@@ -215,8 +215,8 @@ CLASS zcl_ajson_utilities IMPLEMENTATION.
     data lv_path type string.
 
     field-symbols:
-      <node_a> type zcl_ajson=>ty_node,
-      <node_b> type zcl_ajson=>ty_node.
+      <node_a> like line of mo_json_b->mt_json_tree,
+      <node_b> like line of mo_json_b->mt_json_tree.
 
     loop at mo_json_b->mt_json_tree assigning <node_b> where path = iv_path.
       lv_path = <node_b>-path && <node_b>-name && '/'.

--- a/src/zcl_ajson_utilities.clas.abap
+++ b/src/zcl_ajson_utilities.clas.abap
@@ -8,18 +8,18 @@ class zcl_ajson_utilities definition
       importing
         !iv_json_a type string optional
         !iv_json_b type string optional
-        !io_json_a type ref to zcl_ajson optional
-        !io_json_b type ref to zcl_ajson optional
+        !io_json_a type ref to zif_ajson optional
+        !io_json_b type ref to zif_ajson optional
       exporting
-        !eo_insert type ref to zcl_ajson
-        !eo_delete type ref to zcl_ajson
-        !eo_change type ref to zcl_ajson
+        !eo_insert type ref to zif_ajson
+        !eo_delete type ref to zif_ajson
+        !eo_change type ref to zif_ajson
       raising
         zcx_ajson_error .
     methods sort
       importing
         !iv_json         type string optional
-        !io_json         type ref to zcl_ajson optional
+        !io_json         type ref to zif_ajson optional
       returning
         value(rv_sorted) type string
       raising
@@ -28,8 +28,8 @@ class zcl_ajson_utilities definition
 
   private section.
 
-    data mo_json_a type ref to zcl_ajson .
-    data mo_json_b type ref to zcl_ajson .
+    data mo_json_a type ref to zif_ajson .
+    data mo_json_b type ref to zif_ajson .
     data mo_insert type ref to zif_ajson_writer .
     data mo_delete type ref to zif_ajson_writer .
     data mo_change type ref to zif_ajson_writer .
@@ -46,7 +46,7 @@ class zcl_ajson_utilities definition
         zcx_ajson_error .
     methods delete_empty_nodes
       importing
-        !io_json type ref to zcl_ajson
+        !io_json type ref to zif_ajson
       raising
         zcx_ajson_error .
 ENDCLASS.
@@ -245,7 +245,7 @@ CLASS ZCL_AJSON_UTILITIES IMPLEMENTATION.
 
   method sort.
 
-    data lo_json type ref to zcl_ajson.
+    data lo_json type ref to zif_ajson.
 
     if boolc( iv_json is supplied ) = boolc( io_json is supplied ).
       zcx_ajson_error=>raise( 'Either supply JSON string or instance, but not both' ).

--- a/src/zcl_ajson_utilities.clas.testclasses.abap
+++ b/src/zcl_ajson_utilities.clas.testclasses.abap
@@ -139,9 +139,9 @@ class ltcl_json_utils implementation.
     data:
       lv_json       type string,
       lo_util       type ref to zcl_ajson_utilities,
-      lo_insert     type ref to zcl_ajson,
-      lo_delete     type ref to zcl_ajson,
-      lo_change     type ref to zcl_ajson,
+      lo_insert     type ref to zif_ajson,
+      lo_delete     type ref to zif_ajson,
+      lo_change     type ref to zif_ajson,
       lo_insert_exp type ref to lcl_nodes_helper,
       lo_delete_exp type ref to lcl_nodes_helper,
       lo_change_exp type ref to lcl_nodes_helper.
@@ -246,9 +246,9 @@ class ltcl_json_utils implementation.
       lv_json_a     type string,
       lv_json_b     type string,
       lo_util       type ref to zcl_ajson_utilities,
-      lo_insert     type ref to zcl_ajson,
-      lo_delete     type ref to zcl_ajson,
-      lo_change     type ref to zcl_ajson,
+      lo_insert     type ref to zif_ajson,
+      lo_delete     type ref to zif_ajson,
+      lo_change     type ref to zif_ajson,
       lo_insert_exp type ref to lcl_nodes_helper,
       lo_delete_exp type ref to lcl_nodes_helper.
 

--- a/src/zcl_ajson_utilities.clas.testclasses.abap
+++ b/src/zcl_ajson_utilities.clas.testclasses.abap
@@ -5,14 +5,14 @@
 class lcl_nodes_helper definition final.
   public section.
 
-    data mt_nodes type zcl_ajson=>ty_nodes_tt read-only.
+    data mt_nodes type zif_ajson=>ty_nodes_tt read-only.
 
     methods add
       importing
         iv_str type string.
     methods sorted
       returning
-        value(rt_nodes) type zcl_ajson=>ty_nodes_ts.
+        value(rt_nodes) type zif_ajson=>ty_nodes_ts.
 
 endclass.
 

--- a/src/zif_ajson.intf.abap
+++ b/src/zif_ajson.intf.abap
@@ -1,0 +1,77 @@
+interface zif_ajson
+  public .
+
+  constants version type string value 'v1.0.3'.
+  constants origin type string value 'https://github.com/sbcgua/ajson'.
+
+  interfaces zif_ajson_reader.
+  interfaces zif_ajson_writer.
+
+  constants:
+    begin of node_type,
+      boolean type string value 'bool',
+      string  type string value 'str',
+      number  type string value 'num',
+      null    type string value 'null',
+      array   type string value 'array',
+      object  type string value 'object',
+    end of node_type.
+
+  types:
+    begin of ty_node,
+      path type string,
+      name type string,
+      type type string,
+      value type string,
+      index type i,
+      children type i,
+    end of ty_node .
+  types:
+    ty_nodes_tt type standard table of ty_node with key path name .
+  types:
+    ty_nodes_ts type sorted table of ty_node
+      with unique key path name
+      with non-unique sorted key array_index components path index .
+  types:
+    begin of ty_path_name,
+      path type string,
+      name type string,
+    end of ty_path_name.
+
+  " DATA
+
+  data mt_json_tree type ty_nodes_ts read-only.
+
+  " METHODS
+
+  methods freeze.
+
+  " METHODS (merged from reader/writer), maybe will completely move to this IF in future !
+
+  aliases:
+    exists for zif_ajson_reader~exists,
+    members for zif_ajson_reader~members,
+    get for zif_ajson_reader~get,
+    get_boolean for zif_ajson_reader~get_boolean,
+    get_integer for zif_ajson_reader~get_integer,
+    get_number for zif_ajson_reader~get_number,
+    get_date for zif_ajson_reader~get_date,
+    get_string for zif_ajson_reader~get_string,
+    slice for zif_ajson_reader~slice,
+    to_abap for zif_ajson_reader~to_abap,
+    array_to_string_table for zif_ajson_reader~array_to_string_table.
+
+  aliases:
+    clear for zif_ajson_writer~clear,
+    set for zif_ajson_writer~set,
+    set_boolean for zif_ajson_writer~set_boolean,
+    set_string for zif_ajson_writer~set_string,
+    set_integer for zif_ajson_writer~set_integer,
+    set_date for zif_ajson_writer~set_date,
+    set_null for zif_ajson_writer~set_null,
+    delete for zif_ajson_writer~delete,
+    touch_array for zif_ajson_writer~touch_array,
+    push for zif_ajson_writer~push,
+    stringify for zif_ajson_writer~stringify.
+
+endinterface.

--- a/src/zif_ajson.intf.xml
+++ b/src/zif_ajson.intf.xml
@@ -1,0 +1,15 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<abapGit version="v1.0.0" serializer="LCL_OBJECT_INTF" serializer_version="v1.0.0">
+ <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
+  <asx:values>
+   <VSEOINTERF>
+    <CLSNAME>ZIF_AJSON</CLSNAME>
+    <LANGU>E</LANGU>
+    <DESCRIPT>AJSON interface and types</DESCRIPT>
+    <EXPOSURE>2</EXPOSURE>
+    <STATE>1</STATE>
+    <UNICODE>X</UNICODE>
+   </VSEOINTERF>
+  </asx:values>
+ </asx:abap>
+</abapGit>


### PR DESCRIPTION
to #39 

constants, types moved to zif_ajson. All methods aliased from there as well.

@larshp @mbtools What do you think about it ? Imho looks a bit messy ... is there benefits to keep reader/writer ?

- Benefit 1: you can pass instance of ajson to a method, which is intended to use reader or writer only, thus it's params are defined.
- Benefit 2: kind of very clear which methods are changing and which are reading only

- Cons 1: it is convenient to use 1 interface, this is where development process will natively gravitate. It will probably be an "official recommendation" too, so ... will anyone use reader/writer at all ?
- Cons 2: type definition. Makes sense to do it in one place ? zif_ajson. Then reader will depend on zif_ajson and zif_ajson on reader (via alieases) e.g. #41 @jrodriguez-rc 

Any opinions ? :)

P.S. would I separate the interfaces if I designed the whole class initially (and not reader first, and the writer like it happened). I guess, not. Hmmm ...
