### PR TITLE
CI, use setup-node@v2

### DIFF
--- a/.github/workflows/abaplint.yml
+++ b/.github/workflows/abaplint.yml
@@ -12,7 +12,9 @@ jobs:
     name: abaplint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '12'
       - uses: actions/checkout@v2
       - name: Run abaplint # @2.36.9 ?
         run: |


### PR DESCRIPTION
this should make it run a bit faster, plus avoid the warning,

![image](https://user-images.githubusercontent.com/5888506/104092149-5fb73380-5282-11eb-9e2b-85e571dc9dd0.png)
