### PR TITLE
item_order feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,6 +330,26 @@ It is possible to set an instance of ajson immutable (read only). It is done on 
     " }
 ```
 
+#### Keep item order
+
+Sometimes you may want to keep order of json items in the same order as it was in abap structure (assuming you `set` structures or table of structures). To do this call `keep_item_order` after creation of instance, before any `set`.
+
+```abap
+  data:
+    begin of ls_dummy,
+      zulu type string,
+      alpha type string,
+      beta type string,
+    end of ls_dummy.
+
+  li_json->keep_item_order( ).
+  li_json->set(
+    iv_path = '/'
+    iv_val  = ls_dummy ).
+  li_json->stringify( ). " '{"zulu":"z","alpha":"a","beta":"b"}'
+  " otherwise - '{"alpha":"a","beta":"b","zulu":"z"}'
+```
+
 ## Utilities
 
 Class `zcl_ajson_utilities` provides the following methods:

--- a/changelog.txt
+++ b/changelog.txt
@@ -11,6 +11,7 @@ Legend
 v1.0.4, 2021-??
 ------------------
 ! BREAKING: Move types, constants to zif_ajson, also alias methods of reader/writer
++ keep_item_order feature: stringify object elements in the order it appears in abap structure
 
 v1.0.3, 2021-01-09
 ------------------

--- a/src/zif_ajson.intf.abap
+++ b/src/zif_ajson.intf.abap
@@ -24,6 +24,7 @@ interface zif_ajson
       type type string,
       value type string,
       index type i,
+      order type i,
       children type i,
     end of ty_node .
   types:
@@ -31,7 +32,8 @@ interface zif_ajson
   types:
     ty_nodes_ts type sorted table of ty_node
       with unique key path name
-      with non-unique sorted key array_index components path index .
+      with non-unique sorted key array_index components path index
+      with non-unique sorted key item_order components path order .
   types:
     begin of ty_path_name,
       path type string,
@@ -45,6 +47,7 @@ interface zif_ajson
   " METHODS
 
   methods freeze.
+  methods keep_item_order.
 
   " METHODS (merged from reader/writer), maybe will completely move to this IF in future !
 


### PR DESCRIPTION
to #38 

use `keep_item_order` to save struc field order and the serialize will pick it up.

@larshp ready for test, though I will add some docs and maybe refactor some stuff. But the feature is ready and covered with UTs.

P.S. I hope 2 extra table keys are ok for older system. 731 seems to support it ...