### PR TITLE
Remove nested interfaces

### DIFF
--- a/src/zcl_ajson.clas.abap
+++ b/src/zcl_ajson.clas.abap
@@ -4,8 +4,6 @@ class zcl_ajson definition
 
   public section.
 
-    interfaces zif_ajson_reader .
-    interfaces zif_ajson_writer .
     interfaces zif_ajson .
 
     aliases:


### PR DESCRIPTION
The double definition of the reader and writer interfaces is not necessary. It's already included in `zif_ajson`. On 702 it actually causes a dump when importing with abapGit. I suggest removing them from the class definition.