### PR TITLE
additional boolean types

### DIFF
--- a/src/zcl_ajson.clas.locals_imp.abap
+++ b/src/zcl_ajson.clas.locals_imp.abap
@@ -1024,7 +1024,11 @@ class lcl_abap_to_json implementation.
       <n>-name  = is_prefix-name.
     endif.
 
-    if io_type->absolute_name = '\TYPE-POOL=ABAP\TYPE=ABAP_BOOL' or io_type->absolute_name = '\TYPE=XFELD'.
+    if io_type->absolute_name = '\TYPE-POOL=ABAP\TYPE=ABAP_BOOL'
+        or io_type->absolute_name = '\TYPE=ABAP_BOOLEAN'
+        or io_type->absolute_name = '\TYPE=XSDBOOLEAN'
+        or io_type->absolute_name = '\TYPE=FLAG'
+        or io_type->absolute_name = '\TYPE=XFELD'.
       <n>-type = zif_ajson=>node_type-boolean.
       if iv_data is not initial.
         <n>-value = 'true'.


### PR DESCRIPTION
add data elements `abap_boolean`, `xsdboolean`, `flag` to be considered as json booleans

these 3 data elements are in the list of released objects for [Steampunk](https://blogs.sap.com/2019/08/20/its-steampunk-now/)

as a second step, I'd like to replace the use of XFELD in the unit tests to one of these 3 types => #75 