### PR TITLE
Add location to parsing error message

### DIFF
--- a/src/zcl_ajson.clas.locals_imp.abap
+++ b/src/zcl_ajson.clas.locals_imp.abap
@@ -143,12 +143,12 @@ class lcl_json_parser implementation.
     try.
       rt_json_tree = _parse( iv_json ).
     catch cx_sxml_parse_error into lx_sxml.
-        lv_location = _get_location(
-          iv_json   = iv_json
-          iv_offset = lx_sxml->xml_offset ).
-        zcx_ajson_error=>raise(
-          iv_msg      = |Json parsing error (SXML): { lx_sxml->get_text( ) }|
-          iv_location = lv_location ).
+      lv_location = _get_location(
+        iv_json   = iv_json
+        iv_offset = lx_sxml->xml_offset ).
+      zcx_ajson_error=>raise(
+        iv_msg      = |Json parsing error (SXML): { lx_sxml->get_text( ) }|
+        iv_location = lv_location ).
     endtry.
   endmethod.
 

--- a/src/zcl_ajson.clas.testclasses.abap
+++ b/src/zcl_ajson.clas.testclasses.abap
@@ -147,7 +147,22 @@ class ltcl_parser_test implementation.
         exp = '*parsing error*' ).
       cl_abap_unit_assert=>assert_char_cp(
         act = lx_err->location
-        exp = '@PARSER' ).
+        exp = 'Line 1, Offset 1' ).
+    endtry.
+
+    try.
+      lt_act = mo_cut->parse( '{' && cl_abap_char_utilities=>newline
+        && '"ok": "abc",' && cl_abap_char_utilities=>newline
+        && '"error"' && cl_abap_char_utilities=>newline
+        && '}' ).
+      cl_abap_unit_assert=>fail( 'Parsing of invalid JSON must fail (spec)' ).
+    catch zcx_ajson_error into lx_err.
+      cl_abap_unit_assert=>assert_char_cp(
+        act = lx_err->get_text( )
+        exp = '*parsing error*' ).
+      cl_abap_unit_assert=>assert_char_cp(
+        act = lx_err->location
+        exp = 'Line 3, Offset 8' ).
     endtry.
 
   endmethod.


### PR DESCRIPTION
Replace "@PARSER" with "Line x, Offset y" in the parsing error message.

Example in abaplint editor:

![image](https://user-images.githubusercontent.com/59966492/133002848-0ca12dcc-3d67-4dee-b81f-9120718c8e9d.png)
