### PR TITLE
Fix path when using CamelCase

### DIFF
--- a/src/zcl_ajson.clas.locals_imp.abap
+++ b/src/zcl_ajson.clas.locals_imp.abap
@@ -1346,7 +1346,7 @@ class lcl_abap_to_json implementation.
     " and rtti seems to cache type descriptions really well (https://github.com/sbcgua/benchmarks.git)
     " the structures will be repeated in real life
 
-    ls_next_prefix-path = is_prefix-path && is_prefix-name && '/'.
+    ls_next_prefix-path = is_prefix-path && ls_root-name && '/'.
 
     loop at lt_comps assigning <c>.
 

--- a/src/zcl_ajson_mapping.clas.testclasses.abap
+++ b/src/zcl_ajson_mapping.clas.testclasses.abap
@@ -6,6 +6,7 @@ class ltcl_camel_case definition final for testing
     methods:
       to_abap for testing raising zcx_ajson_error,
       to_json for testing raising zcx_ajson_error,
+      to_json_nested_struc for testing raising zcx_ajson_error,
       to_json_first_lower for testing raising zcx_ajson_error.
 
 endclass.
@@ -58,6 +59,35 @@ class ltcl_camel_case implementation.
     cl_abap_unit_assert=>assert_equals(
       act = lo_ajson->stringify( )
       exp = '{"fieldData":"field_value"}' ).
+
+  endmethod.
+
+
+  method to_json_nested_struc.
+
+    data:
+      lo_ajson   type ref to zcl_ajson,
+      li_mapping type ref to zif_ajson_mapping.
+    data:
+      begin of ls_result,
+        field_data type string,
+        begin of struc_data,
+          field_more type string,
+        end of struc_data,
+      end of ls_result.
+
+    li_mapping = zcl_ajson_mapping=>create_camel_case( iv_first_json_upper = abap_false ).
+
+    ls_result-field_data = 'field_value'.
+    ls_result-struc_data-field_more = 'field_more'.
+
+    lo_ajson = zcl_ajson=>create_empty( ii_custom_mapping = li_mapping ).
+
+    lo_ajson->set( iv_path = '/' iv_val = ls_result ).
+
+    cl_abap_unit_assert=>assert_equals(
+      act = lo_ajson->stringify( )
+      exp = '{"fieldData":"field_value","strucData":{"fieldMore":"field_more"}}' ).
 
   endmethod.
 


### PR DESCRIPTION
Closes #95

Before

```json
{  
  "code": "REPORT zfoobar.",
 "fileName": "test.abap",
 "profileInfo": {
  }
}
```

After

```json
{  
  "code": "REPORT zfoobar.",
  "fileName": "test.abap",
  "profileInfo": {
    "showFullname": true,
    "position": "bottom-center"
  }
}
```