### PR TITLE
Fix `REFERENCE_IS_INITIAL` exception

### DIFF
--- a/src/zcl_ajson.clas.locals_imp.abap
+++ b/src/zcl_ajson.clas.locals_imp.abap
@@ -1197,6 +1197,10 @@ class lcl_abap_to_json implementation.
             ct_nodes = ct_nodes ).
 
       when others.
+        " Initial references are ok
+        if iv_data is initial.
+          return.
+        endif.
 
         if io_type->type_kind = cl_abap_typedescr=>typekind_dref.
           convert_ref(


### PR DESCRIPTION
Fix dump in case of components with initial references

