### PR TITLE
Fix `ITAB_DUPLICATE_KEY` and CamelCase

### DIFF
--- a/src/zcl_ajson.clas.locals_imp.abap
+++ b/src/zcl_ajson.clas.locals_imp.abap
@@ -1431,7 +1431,7 @@ class lcl_abap_to_json implementation.
     " and rtti seems to cache type descriptions really well (https://github.com/sbcgua/benchmarks.git)
     " the structures will be repeated in real life
 
-    ls_next_prefix-path = is_prefix-path && ls_root-name && '/'.
+    ls_next_prefix-path = is_prefix-path && <root>-name && '/'.
 
     loop at lt_comps assigning <c>.
 
@@ -1509,7 +1509,7 @@ class lcl_abap_to_json implementation.
     lo_table ?= io_type.
     lo_ltype  = lo_table->get_table_line_type( ).
 
-    ls_next_prefix-path = is_prefix-path && is_prefix-name && '/'.
+    ls_next_prefix-path = is_prefix-path && <root>-name && '/'.
     assign iv_data to <tab>.
 
     lv_tabix = 1.

--- a/src/zcl_ajson.clas.testclasses.abap
+++ b/src/zcl_ajson.clas.testclasses.abap
@@ -1862,7 +1862,7 @@ class ltcl_writer_test definition final
     methods set_obj_w_date_time for testing raising zcx_ajson_error.
     methods set_tab for testing raising zcx_ajson_error.
     methods set_tab_hashed for testing raising zcx_ajson_error.
-    methods set_tab_nested_struct for testing raising zcx_abapgit_ajson_error.
+    methods set_tab_nested_struct for testing raising zcx_ajson_error.
     methods prove_path_exists for testing raising zcx_ajson_error.
     methods delete_subtree for testing raising zcx_ajson_error.
     methods delete for testing raising zcx_ajson_error.

--- a/src/zcl_ajson.clas.testclasses.abap
+++ b/src/zcl_ajson.clas.testclasses.abap
@@ -1862,6 +1862,7 @@ class ltcl_writer_test definition final
     methods set_obj_w_date_time for testing raising zcx_ajson_error.
     methods set_tab for testing raising zcx_ajson_error.
     methods set_tab_hashed for testing raising zcx_ajson_error.
+    methods set_tab_nested_struct for testing raising zcx_abapgit_ajson_error.
     methods prove_path_exists for testing raising zcx_ajson_error.
     methods delete_subtree for testing raising zcx_ajson_error.
     methods delete for testing raising zcx_ajson_error.
@@ -2257,6 +2258,58 @@ class ltcl_writer_test implementation.
 
     li_writer->set(
       iv_path = '/x'
+      iv_val  = lt_tab ).
+    cl_abap_unit_assert=>assert_equals(
+      act = lo_cut->mt_json_tree
+      exp = lo_nodes->sorted( ) ).
+
+  endmethod.
+
+  method set_tab_nested_struct.
+
+    types:
+      begin of ty_include,
+        str type string,
+        int type i,
+      end of ty_include,
+      begin of ty_struct.
+        include type ty_include.
+    types: dat type xstring,
+      end of ty_struct,
+      ty_tab type standard table of ty_struct with default key.
+
+    data lo_nodes type ref to lcl_nodes_helper.
+    data lo_cut type ref to zcl_ajson.
+    data li_writer type ref to zif_ajson.
+    data ls_tab type ty_struct.
+    data lt_tab type ty_tab.
+
+    lo_cut = zcl_ajson=>create_empty( ).
+    li_writer = lo_cut.
+
+    ls_tab-str = 'hello'.
+    ls_tab-int = 123.
+    ls_tab-dat = '4041'.
+    insert ls_tab into table lt_tab.
+    ls_tab-str = 'world'.
+    ls_tab-int = 456.
+    ls_tab-dat = '6061'.
+    insert ls_tab into table lt_tab.
+
+    " prepare source
+    create object lo_nodes.
+    lo_nodes->add( '        |      |array  |     |0|2' ).
+    lo_nodes->add( '/       |1     |object |     |1|3' ).
+    lo_nodes->add( '/       |2     |object |     |2|3' ).
+    lo_nodes->add( '/1/     |dat   |str    |4041 |0|0' ).
+    lo_nodes->add( '/1/     |int   |num    |123  |0|0' ).
+    lo_nodes->add( '/1/     |str   |str    |hello|0|0' ).
+    lo_nodes->add( '/2/     |dat   |str    |6061 |0|0' ).
+    lo_nodes->add( '/2/     |int   |num    |456  |0|0' ).
+    lo_nodes->add( '/2/     |str   |str    |world|0|0' ).
+
+    li_writer->set(
+      iv_path = '/'
       iv_val  = lt_tab ).
     cl_abap_unit_assert=>assert_equals(
       act = lo_cut->mt_json_tree

--- a/src/zcl_ajson.clas.testclasses.abap
+++ b/src/zcl_ajson.clas.testclasses.abap
@@ -2214,7 +2214,7 @@ class ltcl_writer_test implementation.
     data li_writer type ref to zif_ajson.
     data lt_tab type string_table.
 
-    lo_cut = zcl_ajson=>create_empty( )->format_datetime( ).
+    lo_cut = zcl_ajson=>create_empty( ).
     li_writer = lo_cut.
 
     append 'hello' to lt_tab.

--- a/src/zcl_ajson.clas.testclasses.abap
+++ b/src/zcl_ajson.clas.testclasses.abap
@@ -2210,12 +2210,10 @@ class ltcl_writer_test implementation.
   method set_tab.
 
     data lo_nodes type ref to lcl_nodes_helper.
-    data lo_cut type ref to zcl_ajson.
-    data li_writer type ref to zif_ajson.
+    data li_cut type ref to zif_ajson.
     data lt_tab type string_table.
 
-    lo_cut = zcl_ajson=>create_empty( ).
-    li_writer = lo_cut.
+    li_cut = zcl_ajson=>create_empty( ).
 
     append 'hello' to lt_tab.
     append 'world' to lt_tab.
@@ -2227,11 +2225,11 @@ class ltcl_writer_test implementation.
     lo_nodes->add( '/x/     |1     |str    |hello|1|0' ).
     lo_nodes->add( '/x/     |2     |str    |world|2|0' ).
 
-    li_writer->set(
+    li_cut->set(
       iv_path = '/x'
       iv_val  = lt_tab ).
     cl_abap_unit_assert=>assert_equals(
-      act = lo_cut->mt_json_tree
+      act = li_cut->mt_json_tree
       exp = lo_nodes->sorted( ) ).
 
   endmethod.

--- a/src/zcl_ajson.clas.testclasses.abap
+++ b/src/zcl_ajson.clas.testclasses.abap
@@ -2210,10 +2210,12 @@ class ltcl_writer_test implementation.
   method set_tab.
 
     data lo_nodes type ref to lcl_nodes_helper.
-    data li_cut type ref to zif_ajson.
+    data lo_cut type ref to zcl_ajson.
+    data li_writer type ref to zif_ajson.
     data lt_tab type string_table.
 
-    li_cut = zcl_ajson=>create_empty( ).
+    lo_cut = zcl_ajson=>create_empty( )->format_datetime( ).
+    li_writer = lo_cut.
 
     append 'hello' to lt_tab.
     append 'world' to lt_tab.
@@ -2225,11 +2227,11 @@ class ltcl_writer_test implementation.
     lo_nodes->add( '/x/     |1     |str    |hello|1|0' ).
     lo_nodes->add( '/x/     |2     |str    |world|2|0' ).
 
-    li_cut->set(
+    li_writer->set(
       iv_path = '/x'
       iv_val  = lt_tab ).
     cl_abap_unit_assert=>assert_equals(
-      act = li_cut->mt_json_tree
+      act = lo_cut->mt_json_tree
       exp = lo_nodes->sorted( ) ).
 
   endmethod.
@@ -2277,13 +2279,11 @@ class ltcl_writer_test implementation.
       ty_tab type standard table of ty_struct with default key.
 
     data lo_nodes type ref to lcl_nodes_helper.
-    data lo_cut type ref to zcl_ajson.
-    data li_writer type ref to zif_ajson.
+    data li_cut type ref to zif_ajson.
     data ls_tab type ty_struct.
     data lt_tab type ty_tab.
 
-    lo_cut = zcl_ajson=>create_empty( ).
-    li_writer = lo_cut.
+    li_cut = zcl_ajson=>create_empty( ).
 
     ls_tab-str = 'hello'.
     ls_tab-int = 123.
@@ -2306,11 +2306,11 @@ class ltcl_writer_test implementation.
     lo_nodes->add( '/2/     |int   |num    |456  |0|0' ).
     lo_nodes->add( '/2/     |str   |str    |world|0|0' ).
 
-    li_writer->set(
+    li_cut->set(
       iv_path = '/'
       iv_val  = lt_tab ).
     cl_abap_unit_assert=>assert_equals(
-      act = lo_cut->mt_json_tree
+      act = li_cut->mt_json_tree
       exp = lo_nodes->sorted( ) ).
 
   endmethod.

--- a/src/zcl_ajson_mapping.clas.testclasses.abap
+++ b/src/zcl_ajson_mapping.clas.testclasses.abap
@@ -99,6 +99,7 @@ class ltcl_camel_case implementation.
       lo_ajson   type ref to zcl_ajson,
       li_mapping type ref to zif_ajson_mapping.
     data:
+      lv_value type string,
       begin of ls_result,
         field_data type string,
         begin of struc_data,
@@ -109,7 +110,8 @@ class ltcl_camel_case implementation.
     li_mapping = zcl_ajson_mapping=>create_camel_case( iv_first_json_upper = abap_false ).
 
     ls_result-field_data = 'field_value'.
-    insert |field_more| into table ls_result-struc_data-field_more.
+    lv_value = 'field_more'.
+    insert lv_value into table ls_result-struc_data-field_more.
 
     lo_ajson = zcl_ajson=>create_empty( ii_custom_mapping = li_mapping ).
 
@@ -118,7 +120,7 @@ class ltcl_camel_case implementation.
 
     cl_abap_unit_assert=>assert_equals(
       act = lo_ajson->stringify( )
-      exp = '{"fielddata":"field_value","strucdata":{"fieldmore":["field_more"]}}' ).
+      exp = '{"fieldData":"field_value","strucData":{"fieldMore":["field_more"]}}' ).
 
   endmethod.
 

--- a/src/zcl_ajson_mapping.clas.testclasses.abap
+++ b/src/zcl_ajson_mapping.clas.testclasses.abap
@@ -7,6 +7,7 @@ class ltcl_camel_case definition final for testing
       to_abap for testing raising zcx_ajson_error,
       to_json for testing raising zcx_ajson_error,
       to_json_nested_struc for testing raising zcx_ajson_error,
+      to_json_nested_table for testing raising zcx_ajson_error,
       to_json_first_lower for testing raising zcx_ajson_error.
 
 endclass.
@@ -88,6 +89,36 @@ class ltcl_camel_case implementation.
     cl_abap_unit_assert=>assert_equals(
       act = lo_ajson->stringify( )
       exp = '{"fieldData":"field_value","strucData":{"fieldMore":"field_more"}}' ).
+
+  endmethod.
+
+
+  method to_json_nested_table.
+
+    data:
+      lo_ajson   type ref to zcl_ajson,
+      li_mapping type ref to zif_ajson_mapping.
+    data:
+      begin of ls_result,
+        field_data type string,
+        begin of struc_data,
+          field_more type string_table,
+        end of struc_data,
+      end of ls_result.
+
+    li_mapping = zcl_ajson_mapping=>create_camel_case( iv_first_json_upper = abap_false ).
+
+    ls_result-field_data = 'field_value'.
+    insert |field_more| into table ls_result-struc_data-field_more.
+
+    lo_ajson = zcl_ajson=>create_empty( ii_custom_mapping = li_mapping ).
+
+    lo_ajson->set( iv_path = '/'
+                   iv_val = ls_result ).
+
+    cl_abap_unit_assert=>assert_equals(
+      act = lo_ajson->stringify( )
+      exp = '{"fielddata":"field_value","strucdata":{"fieldmore":["field_more"]}}' ).
 
   endmethod.
 


### PR DESCRIPTION
PR #96 was incomplete. It covered nested structures but not nested tables. 
- Test case `set_tab_nested_struct` fails with  `ITAB_DUPLICATE_KEY`
- Test case `to_json_nested_table` fails with incorrect JSON

Fix is to use `<root>-name` for the prefix for `convert_struc` and `convert_table` which is the correct value after mapping.