### PR TITLE
Data serialization: fix dump ITAB_DUPLICATE_KEY

### DIFF
--- a/src/zcl_ajson.clas.locals_imp.abap
+++ b/src/zcl_ajson.clas.locals_imp.abap
@@ -1433,7 +1433,7 @@ class lcl_abap_to_json implementation.
     " and rtti seems to cache type descriptions really well (https://github.com/sbcgua/benchmarks.git)
     " the structures will be repeated in real life
 
-    ls_next_prefix-path = is_prefix-path && <root>-name && '/'.
+    ls_next_prefix-path = is_prefix-path && ls_root-name && '/'.
 
     loop at lt_comps assigning <c>.
 


### PR DESCRIPTION
Hello,
It looks like data serialization doesn't work on tables comprizing of "cascading" include structures.
See also this pull request for pictures and more details:
https://github.com/abapGit/abapGit/pull/5577
Cheers !
Nick.