### PR TITLE
fix timestamp conversion in 731

### DIFF
--- a/src/zcl_ajson.clas.locals_imp.abap
+++ b/src/zcl_ajson.clas.locals_imp.abap
@@ -1041,8 +1041,11 @@ class lcl_json_to_abap implementation.
     endtry.
 
     if lv_timestamp is not initial.
-      " move_to_short fails with initial value
-      rv_result = cl_abap_tstmp=>move_to_short( lv_timestamp ).
+      cl_abap_tstmp=>move(
+        exporting
+          tstmp_src = lv_timestamp
+        importing
+          tstmp_tgt = rv_result ).
     endif.
 
   endmethod.

--- a/src/zcl_ajson.clas.testclasses.abap
+++ b/src/zcl_ajson.clas.testclasses.abap
@@ -3628,13 +3628,14 @@ class ltcl_abap_to_json implementation.
 
     data lo_nodes_exp type ref to lcl_nodes_helper.
     data lt_nodes type zif_ajson=>ty_nodes_tt.
+    data lv_timezone type tzonref-tzone value ''.
 
     data lv_timestamp type timestamp.
     create object lo_nodes_exp.
     lo_nodes_exp->add( '        |      |str |2022-08-31T00:00:00Z||' ).
 
     convert date '20220831' time '000000'
-      into time stamp lv_timestamp time zone ''.
+      into time stamp lv_timestamp time zone lv_timezone.
     lt_nodes = lcl_abap_to_json=>convert( lcl_abap_to_json=>format_timestamp( lv_timestamp ) ).
 
     cl_abap_unit_assert=>assert_equals(


### PR DESCRIPTION
@mbtools FYI
- move to short is missing in 731 (probably in 701 too)
- and it does not accept strings in `convert`
So the former code didn't compile.

Will merge it just a bit later today.