### PR TITLE
Avoid overwriting built-in functions

### DIFF
--- a/abaplint.json
+++ b/abaplint.json
@@ -71,7 +71,7 @@
     "many_parentheses": true,
     "max_one_method_parameter_per_line": true,
     "method_implemented_twice": true,
-    "method_overwrites_builtin": false,
+    "method_overwrites_builtin": true,
     "modify_only_own_db_tables": true,
     "names_no_dash": true,
     "no_aliases": false,

--- a/src/zcl_ajson.clas.locals_imp.abap
+++ b/src/zcl_ajson.clas.locals_imp.abap
@@ -467,7 +467,7 @@ class lcl_json_serializer implementation.
       when zif_ajson=>node_type-object.
         lv_item = lv_item && '{'.
       when zif_ajson=>node_type-string.
-        lv_item = lv_item && |"{ escape_value( is_node-value ) }"|.
+        lv_item = lv_item && |"{ escape_string( is_node-value ) }"|.
       when zif_ajson=>node_type-boolean or zif_ajson=>node_type-number.
         lv_item = lv_item && is_node-value.
       when zif_ajson=>node_type-null.

--- a/src/zcl_ajson.clas.locals_imp.abap
+++ b/src/zcl_ajson.clas.locals_imp.abap
@@ -382,7 +382,7 @@ class lcl_json_serializer definition final create private.
     data mv_indent_step type i.
     data mv_level type i.
 
-    class-methods escape_value
+    class-methods escape_string
       importing
         iv_unescaped type string
       returning
@@ -552,7 +552,7 @@ class lcl_json_serializer implementation.
 
   endmethod.
 
-  method escape_value.
+  method escape_string.
 
     rv_escaped = iv_unescaped.
     if rv_escaped ca |"\\\t\n\r|.

--- a/src/zcl_ajson.clas.locals_imp.abap
+++ b/src/zcl_ajson.clas.locals_imp.abap
@@ -382,7 +382,7 @@ class lcl_json_serializer definition final create private.
     data mv_indent_step type i.
     data mv_level type i.
 
-    class-methods escape
+    class-methods escape_value
       importing
         iv_unescaped type string
       returning
@@ -467,7 +467,7 @@ class lcl_json_serializer implementation.
       when zif_ajson=>node_type-object.
         lv_item = lv_item && '{'.
       when zif_ajson=>node_type-string.
-        lv_item = lv_item && |"{ escape( is_node-value ) }"|.
+        lv_item = lv_item && |"{ escape_value( is_node-value ) }"|.
       when zif_ajson=>node_type-boolean or zif_ajson=>node_type-number.
         lv_item = lv_item && is_node-value.
       when zif_ajson=>node_type-null.
@@ -552,7 +552,7 @@ class lcl_json_serializer implementation.
 
   endmethod.
 
-  method escape.
+  method escape_value.
 
     rv_escaped = iv_unescaped.
     if rv_escaped ca |"\\\t\n\r|.

--- a/src/zcl_ajson.clas.testclasses.abap
+++ b/src/zcl_ajson.clas.testclasses.abap
@@ -405,7 +405,7 @@ class ltcl_serializer_test definition final
     methods item_order for testing raising zcx_ajson_error.
     methods simple_indented for testing raising zcx_ajson_error.
     methods empty_set for testing raising zcx_ajson_error.
-    methods escape for testing raising zcx_ajson_error.
+    methods escape_value for testing raising zcx_ajson_error.
     methods empty for testing raising zcx_ajson_error.
 
 endclass.
@@ -684,7 +684,7 @@ class ltcl_serializer_test implementation.
 
   endmethod.
 
-  method escape.
+  method escape_value.
 
     data lv_act type string.
     data lv_exp type string.

--- a/src/zcl_ajson.clas.testclasses.abap
+++ b/src/zcl_ajson.clas.testclasses.abap
@@ -405,7 +405,7 @@ class ltcl_serializer_test definition final
     methods item_order for testing raising zcx_ajson_error.
     methods simple_indented for testing raising zcx_ajson_error.
     methods empty_set for testing raising zcx_ajson_error.
-    methods escape_value for testing raising zcx_ajson_error.
+    methods escape_string for testing raising zcx_ajson_error.
     methods empty for testing raising zcx_ajson_error.
 
 endclass.
@@ -684,7 +684,7 @@ class ltcl_serializer_test implementation.
 
   endmethod.
 
-  method escape_value.
+  method escape_string.
 
     data lv_act type string.
     data lv_exp type string.


### PR DESCRIPTION
Enable `method_overwrites_builtin` rules