### PR TITLE
Slice performance

### DIFF
--- a/src/core/zcl_ajson.clas.abap
+++ b/src/core/zcl_ajson.clas.abap
@@ -826,22 +826,29 @@ CLASS ZCL_AJSON IMPLEMENTATION.
     data lv_normalized_path type string.
     data ls_path_parts      type zif_ajson_types=>ty_path_name.
     data lv_path_len        type i.
+    data lv_path_pattern    type string.
 
     create object lo_section.
     lv_normalized_path = lcl_utils=>normalize_path( iv_path ).
     lv_path_len        = strlen( lv_normalized_path ).
     ls_path_parts      = lcl_utils=>split_path( lv_normalized_path ).
 
-    loop at mt_json_tree into ls_item.
-      " TODO potentially improve performance due to sorted tree (all path started from same prefix go in a row)
-      if strlen( ls_item-path ) >= lv_path_len
-          and substring( val = ls_item-path len = lv_path_len ) = lv_normalized_path.
-        ls_item-path = substring( val = ls_item-path off = lv_path_len - 1 ). " less closing '/'
-        insert ls_item into table lo_section->mt_json_tree.
-      elseif ls_item-path = ls_path_parts-path and ls_item-name = ls_path_parts-name.
-        clear: ls_item-path, ls_item-name. " this becomes a new root
-        insert ls_item into table lo_section->mt_json_tree.
-      endif.
+    read table mt_json_tree into ls_item
+      with key path = ls_path_parts-path name = ls_path_parts-name.
+    if sy-subrc <> 0.
+      return.
+    endif.
+
+    clear: ls_item-path, ls_item-name. " this becomes a new root
+    insert ls_item into table lo_section->mt_json_tree.
+
+    lv_path_pattern = lv_normalized_path && `*`.
+
+    loop at mt_json_tree into ls_item where path CP lv_path_pattern.
+
+      ls_item-path = substring( val = ls_item-path off = lv_path_len - 1 ). " less closing '/'
+      insert ls_item into table lo_section->mt_json_tree.
+
     endloop.
 
     ri_json = lo_section.

--- a/src/core/zcl_ajson.clas.abap
+++ b/src/core/zcl_ajson.clas.abap
@@ -844,7 +844,7 @@ CLASS ZCL_AJSON IMPLEMENTATION.
 
     lv_path_pattern = lv_normalized_path && `*`.
 
-    loop at mt_json_tree into ls_item where path CP lv_path_pattern.
+    loop at mt_json_tree into ls_item where path cp lv_path_pattern.
 
       ls_item-path = substring( val = ls_item-path off = lv_path_len - 1 ). " less closing '/'
       insert ls_item into table lo_section->mt_json_tree.


### PR DESCRIPTION
Testing this code:

```abap
    DATA:
      BEGIN OF ls_record,
        records TYPE stringtab,
      END OF ls_record.

    TYPES:
      ty_packed TYPE p LENGTH 16 DECIMALS 6.

    DATA(index) = 0.

    DO 5000 TIMES.
      index = index + 1.
      INSERT |Line{ index }| INTO TABLE ls_record-records.
    ENDDO.

    DATA(ajson) = zcl_ajson=>create_empty( ).

    ajson->set( iv_path = `/` iv_val = ls_record ).

    GET RUN TIME FIELD DATA(l_start).

    DO 5000 TIMES.
      ajson->slice( `records` ).
    ENDDO.

    GET RUN TIME FIELD DATA(l_end).

    out->write( |{ l_start } -> { l_end }| ).
    out->write( |Runtime: { CONV ty_packed( ( l_end - l_start ) / 1000000 ) NUMBER = USER } seconds| ).
```

Runtime before: 57,843338 seconds
Runtime after: 33,875135 seconds
<img width="271" alt="image" src="https://user-images.githubusercontent.com/56556686/226704055-60946470-8b7b-4f3a-af0c-320b6423a978.png">

Tests success
<img width="259" alt="image" src="https://user-images.githubusercontent.com/56556686/226704152-31801cfc-59f0-4fa1-a748-d75f5b0528c0.png">
