### PR TITLE
Fix set with keep item order

### DIFF
--- a/src/core/zcl_ajson.clas.abap
+++ b/src/core/zcl_ajson.clas.abap
@@ -126,7 +126,7 @@ ENDCLASS.
 
 
 
-CLASS zcl_ajson IMPLEMENTATION.
+CLASS ZCL_AJSON IMPLEMENTATION.
 
 
   method constructor.
@@ -591,6 +591,7 @@ CLASS zcl_ajson IMPLEMENTATION.
 
     data ls_split_path type zif_ajson_types=>ty_path_name.
     data lr_parent type ref to zif_ajson_types=>ty_node.
+    data ls_deleted_node type zif_ajson_types=>ty_node.
     data lv_item_order type zif_ajson_types=>ty_node-order.
 
     read_only_watchdog( ).
@@ -631,10 +632,11 @@ CLASS zcl_ajson IMPLEMENTATION.
     assert lr_parent is not initial.
 
     " delete if exists with subtree
-    lv_item_order = delete_subtree(
+    ls_deleted_node = delete_subtree(
       ir_parent = lr_parent
       iv_path   = ls_split_path-path
-      iv_name   = ls_split_path-name )-order.
+      iv_name   = ls_split_path-name ).
+    lv_item_order = ls_deleted_node-order.
 
     " convert to json
     data lt_new_nodes type zif_ajson_types=>ty_nodes_tt.
@@ -645,7 +647,7 @@ CLASS zcl_ajson IMPLEMENTATION.
         iv_path  = ls_split_path-path
         iv_index = ls_split_path-name ).
     elseif lr_parent->type = zif_ajson_types=>node_type-object
-      and lv_item_order is initial and ms_opts-keep_item_order = abap_true.
+      and lv_item_order = 0 and ms_opts-keep_item_order = abap_true.
       lv_item_order = lr_parent->children + 1.
     endif.
 

--- a/src/core/zcl_ajson.clas.locals_imp.abap
+++ b/src/core/zcl_ajson.clas.locals_imp.abap
@@ -1155,6 +1155,7 @@ class lcl_abap_to_json definition final.
         io_json type ref to zif_ajson
         is_prefix type zif_ajson_types=>ty_path_name
         iv_index type i default 0
+        iv_item_order type i default 0
       changing
         ct_nodes type zif_ajson_types=>ty_nodes_tt
       raising
@@ -1315,6 +1316,7 @@ class lcl_abap_to_json implementation.
               io_json   = iv_data
               is_prefix = is_prefix
               iv_index  = iv_index
+              iv_item_order = iv_item_order
             changing
               ct_nodes = ct_nodes ).
         else.
@@ -1342,6 +1344,7 @@ class lcl_abap_to_json implementation.
         <dst>-path  = is_prefix-path.
         <dst>-name  = is_prefix-name.
         <dst>-index = iv_index.
+        <dst>-order = iv_item_order.
       else.
         <dst>-path = is_prefix-path && is_prefix-name && <dst>-path.
       endif.

--- a/src/core/zcl_ajson.clas.testclasses.abap
+++ b/src/core/zcl_ajson.clas.testclasses.abap
@@ -2099,6 +2099,7 @@ class ltcl_writer_test definition final
     methods setx for testing raising zcx_ajson_error.
     methods setx_float for testing raising zcx_ajson_error.
     methods setx_complex for testing raising zcx_ajson_error.
+    methods setx_complex_w_keep_order for testing raising zcx_ajson_error.
 
     methods set_with_type_slice
       importing
@@ -3319,6 +3320,27 @@ class ltcl_writer_test implementation.
       cl_abap_unit_assert=>fail( ).
     catch zcx_ajson_error.
     endtry.
+
+  endmethod.
+
+  method setx_complex_w_keep_order.
+
+    data li_cut type ref to zif_ajson.
+
+    li_cut = zcl_ajson=>new( iv_keep_item_order = abap_true ).
+    li_cut->setx( '/c:3' ).
+    li_cut->setx( '/b:2' ).
+    li_cut->setx( '/a:1' ).
+
+    cl_abap_unit_assert=>assert_equals(
+      act = li_cut->stringify( )
+      exp = '{"c":3,"b":2,"a":1}' ).
+
+    li_cut->setx( '/b:{"z":9}' ).
+
+    cl_abap_unit_assert=>assert_equals(
+      act = li_cut->stringify( )
+      exp = '{"c":3,"b":{"z":9},"a":1}' ).
 
   endmethod.
 

--- a/src/core/zcl_ajson.clas.testclasses.abap
+++ b/src/core/zcl_ajson.clas.testclasses.abap
@@ -3326,21 +3326,37 @@ class ltcl_writer_test implementation.
   method setx_complex_w_keep_order.
 
     data li_cut type ref to zif_ajson.
+    data:
+      begin of ls_dummy,
+        f type i value 5,
+        e type i value 6,
+      end of ls_dummy.
 
     li_cut = zcl_ajson=>new( iv_keep_item_order = abap_true ).
     li_cut->setx( '/c:3' ).
-    li_cut->setx( '/b:2' ).
+    li_cut->set(
+      iv_path = '/b'
+      iv_val  = ls_dummy ).
     li_cut->setx( '/a:1' ).
 
     cl_abap_unit_assert=>assert_equals(
       act = li_cut->stringify( )
-      exp = '{"c":3,"b":2,"a":1}' ).
+      exp = '{"c":3,"b":{"f":5,"e":6},"a":1}' ).
 
-    li_cut->setx( '/b:{"z":9}' ).
+    li_cut->setx( '/b:{"z":9,"y":8}' ).
 
     cl_abap_unit_assert=>assert_equals(
       act = li_cut->stringify( )
-      exp = '{"c":3,"b":{"z":9},"a":1}' ).
+      exp = '{"c":3,"b":{"z":9,"y":8},"a":1}' ).
+    " TODO: a subtle bug here. The '/b:{"z":9,"y":8}' creates a json internally
+    " without the ordering. It's just by chance that this UT passes, but the implementation
+    " does not guarantee it. The parser should be instructed to keep the order of the parsed json
+
+    li_cut->setx( '/0:9' ).
+
+    cl_abap_unit_assert=>assert_equals(
+      act = li_cut->stringify( )
+      exp = '{"c":3,"b":{"z":9,"y":8},"a":1,"0":9}' ).
 
   endmethod.
 


### PR DESCRIPTION
When adding or changing nodes using set with keep item order on, the new node was always added with order = 0 (first position). This destroyed the original order. It also made it impossible to generate a JSON where the nodes should to be in a specific order, which is the expectation when setting "keep item order".

The fix preserves the order when changing nodes and also counts up the order when adding new nodes (so they keep in the order they where inserted).

Technical background: 

Keep item order is based on secondary index of the nodes table. However, if all order values are 0, then the sort order is not well defined and does not necessarily match the order in which nodes where inserted.