### PR TITLE
Keep item order when parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -395,7 +395,7 @@ It is possible to set an instance of ajson immutable (read only). It is done on 
 
 #### Keep item order
 
-Sometimes you may want to keep order of json items in the same order as it was in abap structure (assuming you `set` structures or table of structures). To do this call `keep_item_order` after creation of instance, before any `set`.
+Sometimes you may want to keep order of json items in the same order as it was in abap structure (assuming you `set` structures or table of structures). To do this: set `iv_keep_item_order` flag shen creating an instance or call `keep_item_order` after creation of instance, before any `set`.
 
 ```abap
   data:
@@ -411,6 +411,19 @@ Sometimes you may want to keep order of json items in the same order as it was i
     iv_val  = ls_dummy ).
   li_json->stringify( ). " '{"zulu":"z","alpha":"a","beta":"b"}'
   " otherwise - '{"alpha":"a","beta":"b","zulu":"z"}'
+
+  " OR
+  li_json = zcl_ajson=>new( iv_keep_item_order = abap_true ).
+  ...
+```
+
+The same parameter exists for parsing
+
+```abap
+  li_json = zcl_ajson=>parse( 
+    iv_json            = '{"b":1,"a":2}'
+    iv_keep_item_order = abap_true ).
+  li_json->stringify( ). " '{"b":1,"a":2}'
 ```
 
 #### Auto format date/time

--- a/README.md
+++ b/README.md
@@ -395,7 +395,7 @@ It is possible to set an instance of ajson immutable (read only). It is done on 
 
 #### Keep item order
 
-Sometimes you may want to keep order of json items in the same order as it was in abap structure (assuming you `set` structures or table of structures). To do this: set `iv_keep_item_order` flag shen creating an instance or call `keep_item_order` after creation of instance, before any `set`.
+Sometimes you may want to keep order of json items in the same order as it was in abap structure (assuming you `set` structures or table of structures). To do this: set `iv_keep_item_order` flag when creating an instance or call `keep_item_order` after creation of instance, before any `set`.
 
 ```abap
   data:

--- a/changelog.txt
+++ b/changelog.txt
@@ -16,6 +16,7 @@ v1.1.?, 2023-??
 * Fix set with keep item order (#165, @mbtools)
 + iv_corresponding flag in to_abap (#161, #162, @christianguenter2)
 + to_abap_corresponding_only opt flag (#161)
++ Keep item order when parsing #166
 
 v1.1.8, 2023-02-16
 ------------------

--- a/src/core/zcl_ajson.clas.abap
+++ b/src/core/zcl_ajson.clas.abap
@@ -50,9 +50,10 @@ class zcl_ajson definition
 
     class-methods parse
       importing
-        !iv_json           type string
-        !iv_freeze         type abap_bool default abap_false
-        !ii_custom_mapping type ref to zif_ajson_mapping optional
+        !iv_json            type string
+        !iv_freeze          type abap_bool default abap_false
+        !ii_custom_mapping  type ref to zif_ajson_mapping optional
+        !iv_keep_item_order type abap_bool default abap_false
       returning
         value(ro_instance) type ref to zcl_ajson
       raising
@@ -247,8 +248,11 @@ CLASS ZCL_AJSON IMPLEMENTATION.
 
     create object ro_instance.
     create object lo_parser.
-    ro_instance->mt_json_tree = lo_parser->parse( iv_json ).
+    ro_instance->mt_json_tree = lo_parser->parse(
+      iv_json            = iv_json
+      iv_keep_item_order = iv_keep_item_order ).
     ro_instance->mi_custom_mapping = ii_custom_mapping.
+    ro_instance->ms_opts-keep_item_order = iv_keep_item_order.
 
     if iv_freeze = abap_true.
       ro_instance->freeze( ).
@@ -730,7 +734,9 @@ CLASS ZCL_AJSON IMPLEMENTATION.
       "Expect object/array, but no further checks, parser will catch errors
       zif_ajson~set(
         iv_path = lv_path
-        iv_val  = parse( lv_val ) ).
+        iv_val  = parse(
+          iv_json = lv_val
+          iv_keep_item_order = ms_opts-keep_item_order ) ).
     else. " string
       lv_last = strlen( lv_val ) - 1.
       if lv_val+0(1) = '"' and lv_val+lv_last(1) = '"'.
@@ -852,7 +858,7 @@ CLASS ZCL_AJSON IMPLEMENTATION.
       return.
     endif.
 
-    clear: ls_item-path, ls_item-name. " this becomes a new root
+    clear: ls_item-path, ls_item-name, ls_item-order. " this becomes a new root
     insert ls_item into table lo_section->mt_json_tree.
 
     lv_path_pattern = lv_normalized_path && `*`.

--- a/src/core/zcl_ajson.clas.locals_imp.abap
+++ b/src/core/zcl_ajson.clas.locals_imp.abap
@@ -182,6 +182,7 @@ class lcl_json_parser definition final.
     methods parse
       importing
         iv_json type string
+        iv_keep_item_order type abap_bool default abap_false
       returning
         value(rt_json_tree) type zif_ajson_types=>ty_nodes_tt
       raising
@@ -194,6 +195,7 @@ class lcl_json_parser definition final.
 
     data mt_stack type ty_stack_tt.
     data mv_stack_path type string.
+    data mv_keep_item_order type abap_bool.
 
     methods raise
       importing
@@ -224,6 +226,9 @@ class lcl_json_parser implementation.
     data lx_sxml_parse type ref to cx_sxml_parse_error.
     data lx_sxml type ref to cx_dynamic_check.
     data lv_location type string.
+
+    mv_keep_item_order = iv_keep_item_order.
+
     try.
       " TODO sane JSON check:
       " JSON can be true,false,null,(-)digits
@@ -241,6 +246,7 @@ class lcl_json_parser implementation.
         iv_msg      = |Json parsing error (SXML): { lx_sxml->get_text( ) }|
         iv_location = '@PARSER' ).
     endtry.
+
   endmethod.
 
   method _get_location.
@@ -330,6 +336,9 @@ class lcl_json_parser implementation.
                   <item>-name = lo_attr->get_value( ).
                 endif.
               endloop.
+              if mv_keep_item_order = abap_true.
+                <item>-order = lr_stack_top->children.
+              endif.
             endif.
             if <item>-name is initial.
               raise( 'Node without name (maybe not JSON)' ).

--- a/src/core/zcl_ajson.clas.testclasses.abap
+++ b/src/core/zcl_ajson.clas.testclasses.abap
@@ -75,6 +75,7 @@ class ltcl_parser_test definition final
 
     methods setup.
     methods parse for testing raising zcx_ajson_error.
+    methods parse_keeping_order for testing raising zcx_ajson_error.
     methods parse_string for testing raising zcx_ajson_error.
     methods parse_number for testing raising zcx_ajson_error.
     methods parse_float for testing raising zcx_ajson_error.
@@ -341,6 +342,67 @@ class ltcl_parser_test implementation.
       exp = lo_nodes->mt_nodes ).
 
     lt_act = lo_cut->parse( sample_json( |{ cl_abap_char_utilities=>cr_lf }| ) ).
+    cl_abap_unit_assert=>assert_equals(
+      act = lt_act
+      exp = lo_nodes->mt_nodes ).
+
+  endmethod.
+
+  method parse_keeping_order.
+
+    data lo_cut type ref to lcl_json_parser.
+    data lt_act type zif_ajson_types=>ty_nodes_tt.
+    data lo_nodes type ref to lcl_nodes_helper.
+
+    create object lo_nodes.
+    lo_nodes->add( '                 |         |object |                        |  |8 |0' ).
+    lo_nodes->add( '/                |string   |str    |abc                     |  |0 |1' ).
+    lo_nodes->add( '/                |number   |num    |123                     |  |0 |2' ).
+    lo_nodes->add( '/                |float    |num    |123.45                  |  |0 |3' ).
+    lo_nodes->add( '/                |boolean  |bool   |true                    |  |0 |4' ).
+    lo_nodes->add( '/                |false    |bool   |false                   |  |0 |5' ).
+    lo_nodes->add( '/                |null     |null   |                        |  |0 |6' ).
+    lo_nodes->add( '/                |date     |str    |2020-03-15              |  |0 |7' ).
+    lo_nodes->add( '/                |issues   |array  |                        |  |2 |8' ).
+    lo_nodes->add( '/issues/         |1        |object |                        |1 |5 |0' ).
+    lo_nodes->add( '/issues/1/       |message  |str    |Indentation problem ... |  |0 |1' ).
+    lo_nodes->add( '/issues/1/       |key      |str    |indentation             |  |0 |2' ).
+    lo_nodes->add( '/issues/1/       |start    |object |                        |  |2 |3' ).
+    lo_nodes->add( '/issues/1/start/ |row      |num    |4                       |  |0 |1' ).
+    lo_nodes->add( '/issues/1/start/ |col      |num    |3                       |  |0 |2' ).
+    lo_nodes->add( '/issues/1/       |end      |object |                        |  |2 |4' ).
+    lo_nodes->add( '/issues/1/end/   |row      |num    |4                       |  |0 |1' ).
+    lo_nodes->add( '/issues/1/end/   |col      |num    |26                      |  |0 |2' ).
+    lo_nodes->add( '/issues/1/       |filename |str    |./zxxx.prog.abap        |  |0 |5' ).
+    lo_nodes->add( '/issues/         |2        |object |                        |2 |5 |0' ).
+    lo_nodes->add( '/issues/2/       |message  |str    |Remove space before XXX |  |0 |1' ).
+    lo_nodes->add( '/issues/2/       |key      |str    |space_before_dot        |  |0 |2' ).
+    lo_nodes->add( '/issues/2/       |start    |object |                        |  |2 |3' ).
+    lo_nodes->add( '/issues/2/start/ |row      |num    |3                       |  |0 |1' ).
+    lo_nodes->add( '/issues/2/start/ |col      |num    |21                      |  |0 |2' ).
+    lo_nodes->add( '/issues/2/       |end      |object |                        |  |2 |4' ).
+    lo_nodes->add( '/issues/2/end/   |row      |num    |3                       |  |0 |1' ).
+    lo_nodes->add( '/issues/2/end/   |col      |num    |22                      |  |0 |2' ).
+    lo_nodes->add( '/issues/2/       |filename |str    |./zxxx.prog.abap        |  |0 |5' ).
+
+    create object lo_cut.
+    lt_act = lo_cut->parse(
+      iv_json = sample_json( )
+      iv_keep_item_order = abap_true ).
+    cl_abap_unit_assert=>assert_equals(
+      act = lt_act
+      exp = lo_nodes->mt_nodes ).
+
+    lt_act = lo_cut->parse(
+      iv_json = sample_json( |{ cl_abap_char_utilities=>newline }| )
+      iv_keep_item_order = abap_true ).
+    cl_abap_unit_assert=>assert_equals(
+      act = lt_act
+      exp = lo_nodes->mt_nodes ).
+
+    lt_act = lo_cut->parse(
+      iv_json = sample_json( |{ cl_abap_char_utilities=>cr_lf }| )
+      iv_keep_item_order = abap_true ).
     cl_abap_unit_assert=>assert_equals(
       act = lt_act
       exp = lo_nodes->mt_nodes ).


### PR DESCRIPTION
Option to keep node order in parsed json. FYI @larshp @mbtools 

ref: #165