### PR TITLE
Fix: assertion failure caused by include structures with suffixes

### DIFF
--- a/src/core/zcl_ajson.clas.locals_imp.abap
+++ b/src/core/zcl_ajson.clas.locals_imp.abap
@@ -1497,6 +1497,7 @@ class lcl_abap_to_json implementation.
     field-symbols <root> like ls_root.
     field-symbols <c> like line of lt_comps.
     field-symbols <val> type any.
+    field-symbols <fs_data> type any.
 
     " Object root
 
@@ -1540,7 +1541,7 @@ class lcl_abap_to_json implementation.
 
       if <c>-as_include = abap_true.
 
-        ASSIGN COMPONENT <c>-name OF STRUCTURE iv_data TO FIELD-SYMBOL(<fs_data>).
+        ASSIGN COMPONENT <c>-name OF STRUCTURE iv_data TO <fs_data>.
 
         convert_struc(
           exporting

--- a/src/core/zcl_ajson.clas.locals_imp.abap
+++ b/src/core/zcl_ajson.clas.locals_imp.abap
@@ -1202,7 +1202,6 @@ class lcl_abap_to_json definition final.
         iv_item_order type i default 0
       changing
         ct_nodes type zif_ajson_types=>ty_nodes_tt
-        cs_root  type zif_ajson_types=>ty_node optional
       raising
         zcx_ajson_error.
 
@@ -1500,29 +1499,24 @@ class lcl_abap_to_json implementation.
 
     " Object root
 
-    if cs_root is supplied. " call for include structure
-      assign cs_root to <root>.
-    else. " First call
-      ls_root-path  = is_prefix-path.
-      ls_root-name  = is_prefix-name.
-      ls_root-type  = zif_ajson_types=>node_type-object.
-      ls_root-index = iv_index.
+    ls_root-path  = is_prefix-path.
+    ls_root-name  = is_prefix-name.
+    ls_root-type  = zif_ajson_types=>node_type-object.
+    ls_root-index = iv_index.
 
-      if mi_custom_mapping is bound.
-        ls_root-name = mi_custom_mapping->to_json(
-          iv_path = is_prefix-path
-          iv_name = is_prefix-name ).
-      endif.
-
-      if ls_root-name is initial.
-        ls_root-name  = is_prefix-name.
-      endif.
-
-      ls_root-order = iv_item_order.
-
-      append ls_root to ct_nodes assigning <root>.
-
+    if mi_custom_mapping is bound.
+      ls_root-name = mi_custom_mapping->to_json(
+        iv_path = is_prefix-path
+        iv_name = is_prefix-name ).
     endif.
+
+    if ls_root-name is initial.
+      ls_root-name  = is_prefix-name.
+    endif.
+
+    ls_root-order = iv_item_order.
+
+    append ls_root to ct_nodes assigning <root>.
 
     " Object attributes
 

--- a/src/core/zcl_ajson.clas.locals_imp.abap
+++ b/src/core/zcl_ajson.clas.locals_imp.abap
@@ -1497,7 +1497,7 @@ class lcl_abap_to_json implementation.
     field-symbols <root> like ls_root.
     field-symbols <c> like line of lt_comps.
     field-symbols <val> type any.
-    field-symbols <fs_data> type any.
+    field-symbols <include> type any.
 
     " Object root
 
@@ -1541,11 +1541,11 @@ class lcl_abap_to_json implementation.
 
       if <c>-as_include = abap_true.
 
-        ASSIGN COMPONENT <c>-name OF STRUCTURE iv_data TO <fs_data>.
+        ASSIGN COMPONENT <c>-name OF STRUCTURE iv_data TO <include>.
 
         convert_struc(
           exporting
-            iv_data   = <fs_data>
+            iv_data   = <include>
             io_type   = <c>-type
             is_prefix = is_prefix
           changing

--- a/src/core/zcl_ajson.clas.locals_imp.abap
+++ b/src/core/zcl_ajson.clas.locals_imp.abap
@@ -1527,7 +1527,8 @@ class lcl_abap_to_json implementation.
     " Object attributes
 
     lo_struc ?= io_type.
-    lt_comps = lo_struc->get_included_view( ). " <-- replaced call to get_components() with get_included_view() to avoid problems with suffixes in includes.
+    lt_comps = lo_struc->get_included_view( ).
+    " replaced call to get_components() with get_included_view() to avoid problems with suffixes in includes.
     " get_components is potentially much slower than lo_struc->components
     " but ! we still need it to identify booleans
     " and rtti seems to cache type descriptions really well (https://github.com/sbcgua/benchmarks.git)

--- a/src/core/zcl_ajson.clas.locals_imp.abap
+++ b/src/core/zcl_ajson.clas.locals_imp.abap
@@ -1488,7 +1488,7 @@ class lcl_abap_to_json implementation.
   method convert_struc.
 
     data lo_struc type ref to cl_abap_structdescr.
-    data lt_comps type cl_abap_structdescr=>component_table.
+    data lt_comps type cl_abap_structdescr=>included_view.
     data ls_next_prefix like is_prefix.
     data lv_mapping_prefix_name like is_prefix-name.
     data lv_item_order type i.
@@ -1497,7 +1497,6 @@ class lcl_abap_to_json implementation.
     field-symbols <root> like ls_root.
     field-symbols <c> like line of lt_comps.
     field-symbols <val> type any.
-    field-symbols <include> type any.
 
     " Object root
 
@@ -1528,7 +1527,7 @@ class lcl_abap_to_json implementation.
     " Object attributes
 
     lo_struc ?= io_type.
-    lt_comps = lo_struc->get_components( ).
+    lt_comps = lo_struc->get_included_view( ). " <-- replaced call to get_components() with get_included_view() to avoid problems with suffixes in includes.
     " get_components is potentially much slower than lo_struc->components
     " but ! we still need it to identify booleans
     " and rtti seems to cache type descriptions really well (https://github.com/sbcgua/benchmarks.git)
@@ -1539,49 +1538,32 @@ class lcl_abap_to_json implementation.
     loop at lt_comps assigning <c>.
       clear lv_mapping_prefix_name.
 
-      if <c>-as_include = abap_true.
+      <root>-children = <root>-children + 1.
+      ls_next_prefix-name = to_lower( <c>-name ).
+      assign component <c>-name of structure iv_data to <val>.
+      assert sy-subrc = 0.
 
-        assign component <c>-name of structure iv_data TO <include>.
-
-        convert_struc(
-          exporting
-            iv_data   = <include>
-            io_type   = <c>-type
-            is_prefix = is_prefix
-          changing
-            cs_root  = <root>
-            ct_nodes = ct_nodes ).
-
-      else.
-
-        <root>-children = <root>-children + 1.
-        ls_next_prefix-name = to_lower( <c>-name ).
-        assign component <c>-name of structure iv_data to <val>.
-        assert sy-subrc = 0.
-
-        if mi_custom_mapping is bound and <c>-type->kind = cl_abap_typedescr=>kind_elem.
-          lv_mapping_prefix_name = mi_custom_mapping->to_json( iv_path = ls_next_prefix-path
-                                                               iv_name = ls_next_prefix-name ).
-        endif.
-
-        if lv_mapping_prefix_name is not initial.
-          ls_next_prefix-name = lv_mapping_prefix_name.
-        endif.
-
-        if mv_keep_item_order = abap_true.
-          lv_item_order = <root>-children.
-        endif.
-
-        convert_any(
-          exporting
-            iv_data   = <val>
-            io_type   = <c>-type
-            is_prefix = ls_next_prefix
-            iv_item_order = lv_item_order
-          changing
-            ct_nodes = ct_nodes ).
-
+      if mi_custom_mapping is bound and <c>-type->kind = cl_abap_typedescr=>kind_elem.
+        lv_mapping_prefix_name = mi_custom_mapping->to_json( iv_path = ls_next_prefix-path
+                                                             iv_name = ls_next_prefix-name ).
       endif.
+
+      if lv_mapping_prefix_name is not initial.
+        ls_next_prefix-name = lv_mapping_prefix_name.
+      endif.
+
+      if mv_keep_item_order = abap_true.
+        lv_item_order = <root>-children.
+      endif.
+
+      convert_any(
+        exporting
+          iv_data   = <val>
+          io_type   = <c>-type
+          is_prefix = ls_next_prefix
+          iv_item_order = lv_item_order
+        changing
+          ct_nodes = ct_nodes ).
 
     endloop.
 

--- a/src/core/zcl_ajson.clas.locals_imp.abap
+++ b/src/core/zcl_ajson.clas.locals_imp.abap
@@ -1540,9 +1540,11 @@ class lcl_abap_to_json implementation.
 
       if <c>-as_include = abap_true.
 
+        ASSIGN COMPONENT <c>-name OF STRUCTURE iv_data TO FIELD-SYMBOL(<fs_data>).
+
         convert_struc(
           exporting
-            iv_data   = iv_data
+            iv_data   = <fs_data>
             io_type   = <c>-type
             is_prefix = is_prefix
           changing

--- a/src/core/zcl_ajson.clas.locals_imp.abap
+++ b/src/core/zcl_ajson.clas.locals_imp.abap
@@ -1541,7 +1541,7 @@ class lcl_abap_to_json implementation.
 
       if <c>-as_include = abap_true.
 
-        ASSIGN COMPONENT <c>-name OF STRUCTURE iv_data TO <include>.
+        assign component <c>-name of structure iv_data TO <include>.
 
         convert_struc(
           exporting

--- a/src/core/zcl_ajson.clas.testclasses.abap
+++ b/src/core/zcl_ajson.clas.testclasses.abap
@@ -3826,8 +3826,8 @@ class ltcl_abap_to_json definition
     types
       begin of ty_named_include.
         include type ty_struc as named_with_suffix renaming with suffix _suf.
-        types el type string.
-    types
+    types:
+        el type string.
       end of ty_named_include.
 
     methods set_ajson for testing raising zcx_ajson_error.

--- a/src/core/zcl_ajson.clas.testclasses.abap
+++ b/src/core/zcl_ajson.clas.testclasses.abap
@@ -3823,6 +3823,13 @@ class ltcl_abap_to_json definition
         stab type string_table,
       end of ty_struc_complex.
 
+    types
+      begin of ty_named_include.
+        include type ty_struc as named_with_suffix renaming with suffix _suf.
+        types el type string.
+    types
+      end of ty_named_include.
+
     methods set_ajson for testing raising zcx_ajson_error.
     methods set_value_number for testing raising zcx_ajson_error.
     methods set_value_string for testing raising zcx_ajson_error.
@@ -3835,6 +3842,7 @@ class ltcl_abap_to_json definition
     methods set_obj for testing raising zcx_ajson_error.
     methods set_array for testing raising zcx_ajson_error.
     methods set_complex_obj for testing raising zcx_ajson_error.
+    methods set_include_with_suffix for testing raising zcx_ajson_error.
     methods prefix for testing raising zcx_ajson_error.
 
 endclass.
@@ -4106,6 +4114,34 @@ class ltcl_abap_to_json implementation.
     lo_nodes_exp->add( '/      |stab  |array  |     | |2' ).
     lo_nodes_exp->add( '/stab/ |1     |str    |hello|1|0' ).
     lo_nodes_exp->add( '/stab/ |2     |str    |world|2|0' ).
+
+    lt_nodes = lcl_abap_to_json=>convert( iv_data = ls_struc ).
+
+    cl_abap_unit_assert=>assert_equals(
+      act = lt_nodes
+      exp = lo_nodes_exp->mt_nodes ).
+
+  endmethod.
+
+  method set_include_with_suffix.
+
+    data lo_nodes_exp type ref to lcl_nodes_helper.
+    data ls_struc type ty_named_include.
+    data lt_nodes type zif_ajson_types=>ty_nodes_tt.
+
+    ls_struc-a_suf = 'abc'.
+    ls_struc-b_suf = 10.
+    ls_struc-c_suf = abap_true.
+    ls_struc-d_suf = 'X'.
+    ls_struc-el    = 'elem'.
+
+    create object lo_nodes_exp.
+    lo_nodes_exp->add( '       |      |object |     ||5' ).
+    lo_nodes_exp->add( '/      |a_suf |str    |abc  ||0' ).
+    lo_nodes_exp->add( '/      |b_suf |num    |10   ||0' ).
+    lo_nodes_exp->add( '/      |c_suf |bool   |true ||0' ).
+    lo_nodes_exp->add( '/      |d_suf |bool   |true ||0' ).
+    lo_nodes_exp->add( '/      |el    |str    |elem ||0' ).
 
     lt_nodes = lcl_abap_to_json=>convert( iv_data = ls_struc ).
 

--- a/src/core/zcl_ajson.clas.testclasses.abap
+++ b/src/core/zcl_ajson.clas.testclasses.abap
@@ -3827,7 +3827,7 @@ class ltcl_abap_to_json definition
       begin of ty_named_include.
         include type ty_struc as named_with_suffix renaming with suffix _suf.
     types:
-        el type string.
+        el type string,
       end of ty_named_include.
 
     methods set_ajson for testing raising zcx_ajson_error.


### PR DESCRIPTION
In recursive calls of convert_struc() on suffixed include structures, the data holds the entire structure that the include structure is part of, so components of the include are suffixed, however the type is determined from the include structure alone, so the component list holds component names without their suffix. This leads to an ASSERTION_FAILURE error after component assignment fails because the names do not match.