### PR TITLE
Fix `touch_array` with keep order

### DIFF
--- a/src/core/zcl_ajson.clas.abap
+++ b/src/core/zcl_ajson.clas.abap
@@ -127,7 +127,7 @@ ENDCLASS.
 
 
 
-CLASS ZCL_AJSON IMPLEMENTATION.
+CLASS zcl_ajson IMPLEMENTATION.
 
 
   method constructor.
@@ -923,8 +923,12 @@ CLASS ZCL_AJSON IMPLEMENTATION.
       ls_new_node-name = ls_split_path-name.
       ls_new_node-type = zif_ajson_types=>node_type-array.
 
-      if ms_opts-keep_item_order = abap_true and ls_deleted_node is not initial.
-        ls_new_node-order = ls_deleted_node-order.
+      if ms_opts-keep_item_order = abap_true.
+        if ls_deleted_node is not initial.
+          ls_new_node-order = ls_deleted_node-order.
+        else.
+          ls_new_node-order = lr_parent->children.
+        endif.
       endif.
 
       insert ls_new_node into table mt_json_tree.

--- a/src/core/zcl_ajson.clas.testclasses.abap
+++ b/src/core/zcl_ajson.clas.testclasses.abap
@@ -2196,6 +2196,7 @@ class ltcl_writer_test definition final
     methods read_only for testing raising zcx_ajson_error.
     methods set_array_obj for testing raising zcx_ajson_error.
     methods set_with_type for testing raising zcx_ajson_error.
+    methods new_array_w_keep_order_touch for testing raising zcx_ajson_error.
     methods overwrite_w_keep_order_touch for testing raising zcx_ajson_error.
     methods overwrite_w_keep_order_set for testing raising zcx_ajson_error.
     methods setx for testing raising zcx_ajson_error.
@@ -3266,6 +3267,37 @@ class ltcl_writer_test implementation.
     cl_abap_unit_assert=>assert_equals(
       act = li_cut->stringify( )
       exp = '{"b":0,"a":1}' ). " still ordered after overwrite
+
+  endmethod.
+
+  method new_array_w_keep_order_touch.
+
+    data li_cut type ref to zif_ajson.
+
+    " default order adds new arrays at beginning of node (pos 0)
+    li_cut = zcl_ajson=>create_empty(
+    )->set(
+      iv_path = '/b'
+      iv_val  = 1 ).
+
+    li_cut->touch_array( '/a' ).
+
+    cl_abap_unit_assert=>assert_equals(
+      act = li_cut->stringify( )
+      exp = '{"a":[],"b":1}' ).
+
+    " with keep order, new array is created at end of node
+    li_cut = zcl_ajson=>create_empty(
+    )->keep_item_order(
+    )->set(
+      iv_path = '/b'
+      iv_val  = 1 ).
+
+    li_cut->touch_array( '/a' ).
+
+    cl_abap_unit_assert=>assert_equals(
+      act = li_cut->stringify( )
+      exp = '{"b":1,"a":[]}' ).
 
   endmethod.
 


### PR DESCRIPTION
By default `touch_array` inserts the array at the top of the node. When keep order is set to true, `touch_array` will now insert *new* arrays at the end of the node. 

PS: Overwritting existing nodes already kept their position.

Closes #177