### PR TITLE
JSON_TO_ABAP: fix compressed JSON array to sorted/hashed table keeping components problem

### DIFF
--- a/src/core/zcl_ajson.clas.locals_imp.abap
+++ b/src/core/zcl_ajson.clas.locals_imp.abap
@@ -887,6 +887,8 @@ class lcl_json_to_abap implementation.
             if is_parent_type-tab_item_buf is not bound. " Indirect hint that table was srt/hsh, see get_node_type
               append initial line to <parent_stdtab> reference into lr_target_field.
               assert sy-subrc = 0.
+            else.
+              clear <tab_item>.
             endif.
 
           when lif_kind=>struct_flat or lif_kind=>struct_deep.
@@ -908,9 +910,6 @@ class lcl_json_to_abap implementation.
             if ls_node_type-type_kind <> lif_kind=>struct_flat and
                ls_node_type-type_kind <> lif_kind=>struct_deep.
               zcx_ajson_error=>raise( 'Expected structure' ).
-            endif.
-            if <tab_item> is assigned.
-              clear <tab_item>.
             endif.
             any_to_abap(
               iv_path         = <n>-path && <n>-name && '/'

--- a/src/core/zcl_ajson.clas.locals_imp.abap
+++ b/src/core/zcl_ajson.clas.locals_imp.abap
@@ -909,6 +909,9 @@ class lcl_json_to_abap implementation.
                ls_node_type-type_kind <> lif_kind=>struct_deep.
               zcx_ajson_error=>raise( 'Expected structure' ).
             endif.
+            if <tab_item> is assigned.
+              clear <tab_item>.
+            endif.
             any_to_abap(
               iv_path         = <n>-path && <n>-name && '/'
               is_parent_type  = ls_node_type

--- a/src/core/zcl_ajson.clas.testclasses.abap
+++ b/src/core/zcl_ajson.clas.testclasses.abap
@@ -1464,6 +1464,21 @@ class ltcl_json_to_abap definition
     methods to_abap_str_to_packed
       for testing
       raising cx_static_check.
+    methods to_abap_compressed_stdrd
+      for testing
+      raising cx_static_check.
+    methods to_abap_compressed_stdrd_key
+      for testing
+      raising cx_static_check.
+    methods to_abap_compressed_sort
+      for testing
+      raising cx_static_check.
+    methods to_abap_compressed_sort_unique
+      for testing
+      raising cx_static_check.
+    methods to_abap_compressed_hash
+      for testing
+      raising cx_static_check.
 endclass.
 
 class zcl_ajson definition local friends ltcl_json_to_abap.
@@ -2184,6 +2199,171 @@ class ltcl_json_to_abap implementation.
         act = lx->message
         exp = 'Path not found' ).
     endtry.
+
+  endmethod.
+
+  method to_abap_compressed_stdrd.
+
+    types: begin of ty_foo_bar,
+             foo type string,
+             bar type string,
+           end of ty_foo_bar.
+
+    data lt_foo_bar type standard table of ty_foo_bar.
+    data ls_foo_bar like line of lt_foo_bar.
+    data lo_ajson type ref to zcl_ajson.
+    data lv_json type string.
+
+    lv_json =
+    '[' &&
+    '  {' &&
+    '    "foo": "abc",' &&
+    '    "bar": "123"' &&
+    '  },' &&
+    '  {' &&
+    '    "foo": "cde"' &&
+    '  }' &&
+    ']'.
+
+    lo_ajson = zcl_ajson=>parse( lv_json ).
+
+    lo_ajson->to_abap( importing ev_container = lt_foo_bar ).
+
+    read table lt_foo_bar with key foo = 'cde' into ls_foo_bar.
+
+    cl_abap_unit_assert=>assert_initial( act = ls_foo_bar-bar ).
+
+  endmethod.
+
+  method to_abap_compressed_stdrd_key.
+
+    types: begin of ty_foo_bar,
+             foo type string,
+             bar type string,
+           end of ty_foo_bar.
+
+    data lt_foo_bar type standard table of ty_foo_bar with non-unique key foo.
+    data ls_foo_bar like line of lt_foo_bar.
+    data lo_ajson type ref to zcl_ajson.
+    data lv_json type string.
+
+    lv_json =
+    '[' &&
+    '  {' &&
+    '    "foo": "abc",' &&
+    '    "bar": "123"' &&
+    '  },' &&
+    '  {' &&
+    '    "foo": "cde"' &&
+    '  }' &&
+    ']'.
+
+    lo_ajson = zcl_ajson=>parse( lv_json ).
+
+    lo_ajson->to_abap( importing ev_container = lt_foo_bar ).
+
+    read table lt_foo_bar with key foo = 'cde' into ls_foo_bar.
+
+    cl_abap_unit_assert=>assert_initial( act = ls_foo_bar-bar ).
+
+  endmethod.
+
+  method to_abap_compressed_sort.
+
+    types: begin of ty_foo_bar,
+             foo type string,
+             bar type string,
+           end of ty_foo_bar.
+
+    data lt_foo_bar type sorted table of ty_foo_bar with non-unique key foo.
+    data ls_foo_bar like line of lt_foo_bar.
+    data lo_ajson type ref to zcl_ajson.
+    data lv_json type string.
+
+    lv_json =
+    '[' &&
+    '  {' &&
+    '    "foo": "abc",' &&
+    '    "bar": "123"' &&
+    '  },' &&
+    '  {' &&
+    '    "foo": "cde"' &&
+    '  }' &&
+    ']'.
+
+    lo_ajson = zcl_ajson=>parse( lv_json ).
+
+    lo_ajson->to_abap( importing ev_container = lt_foo_bar ).
+
+    read table lt_foo_bar with key foo = 'cde' into ls_foo_bar.
+
+    cl_abap_unit_assert=>assert_initial( act = ls_foo_bar-bar ).
+
+  endmethod.
+
+  method to_abap_compressed_sort_unique.
+
+    types: begin of ty_foo_bar,
+             foo type string,
+             bar type string,
+           end of ty_foo_bar.
+
+    data lt_foo_bar type sorted table of ty_foo_bar with unique key foo.
+    data ls_foo_bar like line of lt_foo_bar.
+    data lo_ajson type ref to zcl_ajson.
+    data lv_json type string.
+
+    lv_json =
+    '[' &&
+    '  {' &&
+    '    "foo": "abc",' &&
+    '    "bar": "123"' &&
+    '  },' &&
+    '  {' &&
+    '    "foo": "cde"' &&
+    '  }' &&
+    ']'.
+
+    lo_ajson = zcl_ajson=>parse( lv_json ).
+
+    lo_ajson->to_abap( importing ev_container = lt_foo_bar ).
+
+    read table lt_foo_bar with key foo = 'cde' into ls_foo_bar.
+
+    cl_abap_unit_assert=>assert_initial( act = ls_foo_bar-bar ).
+
+  endmethod.
+
+  method to_abap_compressed_hash.
+
+    types: begin of ty_foo_bar,
+             foo type string,
+             bar type string,
+           end of ty_foo_bar.
+
+    data lt_foo_bar type hashed table of ty_foo_bar with unique key foo.
+    data ls_foo_bar like line of lt_foo_bar.
+    data lo_ajson type ref to zcl_ajson.
+    data lv_json type string.
+
+    lv_json =
+    '[' &&
+    '  {' &&
+    '    "foo": "abc",' &&
+    '    "bar": "123"' &&
+    '  },' &&
+    '  {' &&
+    '    "foo": "cde"' &&
+    '  }' &&
+    ']'.
+
+    lo_ajson = zcl_ajson=>parse( lv_json ).
+
+    lo_ajson->to_abap( importing ev_container = lt_foo_bar ).
+
+    read table lt_foo_bar with key foo = 'cde' into ls_foo_bar.
+
+    cl_abap_unit_assert=>assert_initial( act = ls_foo_bar-bar ).
 
   endmethod.
 


### PR DESCRIPTION
This PR reproduces the issue that is tracked https://github.com/sbcgua/ajson/issues/181 and contains a fix proposal.