### PR TITLE
fixed array sort when filtering

### DIFF
--- a/src/core/zcl_ajson.clas.locals_imp.abap
+++ b/src/core/zcl_ajson.clas.locals_imp.abap
@@ -1800,8 +1800,13 @@ class lcl_filter_runner implementation.
   method walk.
 
     data ls_node type zif_ajson_types=>ty_node.
+    data lv_tab_key type string.
 
-    loop at mr_source_tree->* into ls_node where path = iv_path.
+    if cs_parent-type = zif_ajson_types=>node_type-array.
+      lv_tab_key = 'array_index'. " path + index
+    endif.
+
+    loop at mr_source_tree->* into ls_node using key (lv_tab_key) where path = iv_path.
       case ls_node-type.
         when zif_ajson_types=>node_type-boolean or zif_ajson_types=>node_type-null
           or zif_ajson_types=>node_type-number or zif_ajson_types=>node_type-string.

--- a/src/core/zcl_ajson.clas.testclasses.abap
+++ b/src/core/zcl_ajson.clas.testclasses.abap
@@ -4406,15 +4406,47 @@ class ltcl_filter_test implementation.
     lo_json->push(
       iv_path = '/'
       iv_val  = 'b' ).
+    lo_json->push(
+      iv_path = '/'
+      iv_val  = 'c' ).
+    lo_json->push(
+      iv_path = '/'
+      iv_val  = 'd' ).
+    lo_json->push(
+      iv_path = '/'
+      iv_val  = 'e' ).
+    lo_json->push(
+      iv_path = '/'
+      iv_val  = 'f' ).
+    lo_json->push(
+      iv_path = '/'
+      iv_val  = 'g' ).
+    lo_json->push(
+      iv_path = '/'
+      iv_val  = 'h' ).
+    lo_json->push(
+      iv_path = '/'
+      iv_val  = 'i' ).
+    lo_json->push(
+      iv_path = '/'
+      iv_val  = 'j' ).
 
     lo_json_filtered = zcl_ajson=>create_from(
       ii_source_json = lo_json
       ii_filter      = me ).
 
     create object lo_nodes_exp.
-    lo_nodes_exp->add( '       |      |array  |     | |2' ).
+    lo_nodes_exp->add( '       |      |array  |     | |10' ).
     lo_nodes_exp->add( '/      |1     |str    |a    |1|0' ).
     lo_nodes_exp->add( '/      |2     |str    |b    |2|0' ).
+    lo_nodes_exp->add( '/      |3     |str    |c    |3|0' ).
+    lo_nodes_exp->add( '/      |4     |str    |d    |4|0' ).
+    lo_nodes_exp->add( '/      |5     |str    |e    |5|0' ).
+    lo_nodes_exp->add( '/      |6     |str    |f    |6|0' ).
+    lo_nodes_exp->add( '/      |7     |str    |g    |7|0' ).
+    lo_nodes_exp->add( '/      |8     |str    |h    |8|0' ).
+    lo_nodes_exp->add( '/      |9     |str    |i    |9|0' ).
+    lo_nodes_exp->add( '/      |10    |str    |j    |10|0' ).
 
     cl_abap_unit_assert=>assert_equals(
       act = lo_json_filtered->mt_json_tree


### PR DESCRIPTION
When filtering an array with >= 10 entries, the order is mixed up