### PR TITLE
Add option to `stringify` for trailing commas

### DIFF
--- a/src/core/zcl_ajson.clas.abap
+++ b/src/core/zcl_ajson.clas.abap
@@ -880,6 +880,7 @@ CLASS zcl_ajson IMPLEMENTATION.
     rv_json = lcl_json_serializer=>stringify(
       it_json_tree       = mt_json_tree
       iv_keep_item_order = ms_opts-keep_item_order
+      iv_trailing_comma  = iv_trailing_comma
       iv_indent          = iv_indent ).
 
   endmethod.

--- a/src/core/zcl_ajson.clas.locals_imp.abap
+++ b/src/core/zcl_ajson.clas.locals_imp.abap
@@ -401,6 +401,7 @@ class lcl_json_serializer definition final create private.
         it_json_tree type zif_ajson_types=>ty_nodes_ts
         iv_indent type i default 0
         iv_keep_item_order type abap_bool default abap_false
+        iv_trailing_comma type abap_bool default abap_false
       returning
         value(rv_json_string) type string
       raising
@@ -414,6 +415,7 @@ class lcl_json_serializer definition final create private.
 
     data mt_json_tree type zif_ajson_types=>ty_nodes_ts.
     data mv_keep_item_order type abap_bool.
+    data mv_trailing_comma type abap_bool.
     data mt_buffer type string_table.
     data mv_indent_step type i.
     data mv_level type i.
@@ -458,6 +460,7 @@ class lcl_json_serializer implementation.
     lo->mt_json_tree = it_json_tree.
     lo->mv_indent_step = iv_indent.
     lo->mv_keep_item_order = iv_keep_item_order.
+    lo->mv_trailing_comma = iv_trailing_comma.
     rv_json_string = lo->_stringify( ).
 
   endmethod.
@@ -583,7 +586,11 @@ class lcl_json_serializer implementation.
     endloop.
 
     if mv_indent_step > 0 and lv_first_done = abap_true. " only of items were in the list
-      append cl_abap_char_utilities=>newline to mt_buffer.
+      if mv_trailing_comma = abap_true.
+        append gv_comma_with_lf to mt_buffer.
+      else.
+        append cl_abap_char_utilities=>newline to mt_buffer.
+      endif.
     endif.
 
   endmethod.

--- a/src/core/zcl_ajson.clas.testclasses.abap
+++ b/src/core/zcl_ajson.clas.testclasses.abap
@@ -463,6 +463,7 @@ class ltcl_serializer_test definition final
 
     methods stringify_condensed for testing raising zcx_ajson_error.
     methods stringify_indented for testing raising zcx_ajson_error.
+    methods stringify_with_comma for testing raising zcx_ajson_error.
     methods array_index for testing raising zcx_ajson_error.
     methods item_order for testing raising zcx_ajson_error.
     methods simple_indented for testing raising zcx_ajson_error.
@@ -622,6 +623,49 @@ class ltcl_serializer_test implementation.
       it_json_tree = sample_nodes( )
       iv_indent    = 2 ).
     lv_exp = sample_json( ).
+
+    cl_abap_unit_assert=>assert_equals(
+      act = lv_act
+      exp = lv_exp ).
+
+  endmethod.
+
+  method stringify_with_comma.
+
+    data lv_act type string.
+    data lv_exp type string.
+
+    lv_act = lcl_json_serializer=>stringify(
+      it_json_tree      = sample_nodes( )
+      iv_indent         = 2
+      iv_trailing_comma = abap_true ).
+    lv_exp = sample_json( ).
+
+    lv_exp = replace(
+      val = lv_exp
+      sub = |4\n|
+      with = |4,\n|
+      occ = 0 ).
+    lv_exp = replace(
+      val = lv_exp
+      sub = |3\n|
+      with = |3,\n|
+      occ = 0 ).
+    lv_exp = replace(
+      val = lv_exp
+      sub = |"abc"\n|
+      with = |"abc",\n|
+      occ = 0 ).
+    lv_exp = replace(
+      val = lv_exp
+      sub = |\}\n|
+      with = |\},\n|
+      occ = 0 ).
+    lv_exp = replace(
+      val = lv_exp
+      sub = |]\n|
+      with = |],\n|
+      occ = 0 ).
 
     cl_abap_unit_assert=>assert_equals(
       act = lv_act

--- a/src/core/zif_ajson.intf.abap
+++ b/src/core/zif_ajson.intf.abap
@@ -254,6 +254,7 @@ interface zif_ajson
   methods stringify
     importing
       iv_indent type i default 0
+      iv_trailing_comma type abap_bool default abap_false
     returning
       value(rv_json) type string
     raising

--- a/src/core/zif_ajson.intf.abap
+++ b/src/core/zif_ajson.intf.abap
@@ -255,6 +255,7 @@ interface zif_ajson
     importing
       iv_indent type i default 0
       iv_trailing_comma type abap_bool default abap_false
+        preferred parameter iv_indent
     returning
       value(rv_json) type string
     raising


### PR DESCRIPTION
Setting `iv_trailing_comma = abap_true` adds a comma to the last node of objects and arrays. This reduces diffs when comparing JSON files, for example.

Example:

```abap
" regular
lo_json->stringify( iv_indent = 2 ).
```

```json
{
  "boolean": true,
  "date": "2020-03-15",
  "false": false,
  "float": 123.45,
  "issues": [
    {
      "end": {
        "col": 26,
        "row": 4
      },
      "filename": "./zxxx.prog.abap",
      "key": "indentation",
      "message": "Indentation problem ...",
      "start": {
        "col": 3,
        "row": 4
      }
    },
    {
      "end": {
        "col": 22,
        "row": 3
      },
      "filename": "./zxxx.prog.abap",
      "key": "space_before_dot",
      "message": "Remove space before XXX",
      "start": {
        "col": 21,
        "row": 3
      }
    }
  ],
  "null": null,
  "number": 123,
  "string": "abc"
}
```

```abap
" with trailing commas
lo_json->stringify(
  iv_indent         = 2 
  iv_trailing_comma = abap_true ).
```

```json
{
  "boolean": true,
  "date": "2020-03-15",
  "false": false,
  "float": 123.45,
  "issues": [
    {
      "end": {
        "col": 26,
        "row": 4,
      },
      "filename": "./zxxx.prog.abap",
      "key": "indentation",
      "message": "Indentation problem ...",
      "start": {
        "col": 3,
        "row": 4,
      },
    },
    {
      "end": {
        "col": 22,
        "row": 3,
      },
      "filename": "./zxxx.prog.abap",
      "key": "space_before_dot",
      "message": "Remove space before XXX",
      "start": {
        "col": 21,
        "row": 3,
      },
    },
  ],
  "null": null,
  "number": 123,
  "string": "abc",
}
```