### PR TITLE
Special characters (also nodes containing `/`)

### DIFF
--- a/abaplint.jsonc
+++ b/abaplint.jsonc
@@ -73,7 +73,9 @@
     "names_no_dash": true,
     "no_aliases": false,
     "no_chained_assignment": true,
-    "7bit_ascii": true,
+    "7bit_ascii": {
+      "exclude": ["zcl_ajson.clas.testclasses.abap"]
+    },
     "abapdoc": false,
     "allowed_object_naming": true,
     "allowed_object_types": true,

--- a/src/core/zcl_ajson.clas.locals_imp.abap
+++ b/src/core/zcl_ajson.clas.locals_imp.abap
@@ -216,6 +216,11 @@ class lcl_utils implementation.
 
     rv_path_name-path = normalize_path( substring( val = iv_path len = lv_offs ) ).
     rv_path_name-name = substring( val = iv_path off = lv_offs len = lv_len - lv_offs - lv_trim_slash ).
+    rv_path_name-name = replace(
+      val  = rv_path_name-name
+      sub  = cl_abap_char_utilities=>horizontal_tab
+      with = '/'
+      occ  = 0 ).
 
   endmethod.
 

--- a/src/core/zcl_ajson.clas.locals_imp.abap
+++ b/src/core/zcl_ajson.clas.locals_imp.abap
@@ -216,6 +216,7 @@ class lcl_utils implementation.
 
     rv_path_name-path = normalize_path( substring( val = iv_path len = lv_offs ) ).
     rv_path_name-name = substring( val = iv_path off = lv_offs len = lv_len - lv_offs - lv_trim_slash ).
+    " Replace tabs with slash to get original value
     rv_path_name-name = replace(
       val  = rv_path_name-name
       sub  = cl_abap_char_utilities=>horizontal_tab
@@ -475,7 +476,8 @@ class lcl_json_parser implementation.
           mv_stack_path = mv_stack_path && replace(
             val  = <item>-name
             sub  = '/'
-            with = cl_abap_char_utilities=>horizontal_tab )
+            with = cl_abap_char_utilities=>horizontal_tab
+            occ  = 0 )
             && '/'.
 
         when if_sxml_node=>co_nt_element_close.

--- a/src/core/zcl_ajson.clas.locals_imp.abap
+++ b/src/core/zcl_ajson.clas.locals_imp.abap
@@ -466,8 +466,12 @@ class lcl_json_parser implementation.
 
           get reference of <item> into lr_stack_top.
           insert lr_stack_top into mt_stack index 1.
-          " add path component
-          mv_stack_path = mv_stack_path && <item>-name && '/'.
+          " add path component (avoid issues with names containing slashes)
+          mv_stack_path = mv_stack_path && replace(
+            val  = <item>-name
+            sub  = '/'
+            with = cl_abap_char_utilities=>horizontal_tab )
+            && '/'.
 
         when if_sxml_node=>co_nt_element_close.
           data lo_close type ref to if_sxml_close_element.

--- a/src/core/zcl_ajson.clas.testclasses.abap
+++ b/src/core/zcl_ajson.clas.testclasses.abap
@@ -91,6 +91,9 @@ class ltcl_parser_test definition final
     methods parse_input_error for testing raising zcx_ajson_error.
     methods duplicate_key for testing raising zcx_ajson_error.
     methods non_json for testing raising zcx_ajson_error.
+    methods special_characters_in_name for testing raising zcx_ajson_error.
+    methods special_characters_in_path for testing raising zcx_ajson_error.
+    methods special_characters_in_value for testing raising zcx_ajson_error.
 
 endclass.
 
@@ -515,6 +518,79 @@ class ltcl_parser_test implementation.
 
   endmethod.
 
+  method special_characters_in_name.
+    mo_nodes->add( |                 \|                 \|object \|                        \|  \|6| ).
+    mo_nodes->add( |/                \|a\\backslash     \|num    \|1                       \|  \|0| ).
+    mo_nodes->add( |/                \|contains/slash   \|num    \|2                       \|  \|0| ).
+    mo_nodes->add( |/                \|unicodeሴ         \|num    \|3                       \|  \|0| ).
+    mo_nodes->add( |/                \|quoted"text"     \|num    \|4                       \|  \|0| ).
+    mo_nodes->add( |/                \|line\nfeed       \|num    \|5                       \|  \|0| ).
+    mo_nodes->add( |/                \|with\ttab        \|num    \|6                       \|  \|0| ).
+
+    data lt_act type zif_ajson_types=>ty_nodes_tt.
+    data lv_str type string.
+
+    lv_str = '{ "a\\backslash": 1, "contains/slash": 2, "unicode\u1234": 3,'
+          && ' "quoted\"text\"": 4, "line\nfeed": 5, "with\ttab": 6 }'.
+    lt_act = mo_cut->parse( lv_str ).
+
+    cl_abap_unit_assert=>assert_equals(
+      act = lt_act
+      exp = mo_nodes->mt_nodes ).
+
+  endmethod.
+
+  method special_characters_in_path.
+    mo_nodes->add( |                 \|                 \|object \|                        \|  \|6| ).
+    mo_nodes->add( |/                \|a\\backslash     \|object \|                        \|  \|1| ).
+    mo_nodes->add( |/a\\backslash/   \|a                \|num    \|1                       \|  \|0| ).
+    mo_nodes->add( |/                \|contains/slash   \|object \|                        \|  \|1| ).
+    mo_nodes->add( |/contains\tslash/\|b                \|num    \|2                       \|  \|0| ). " tab!
+    mo_nodes->add( |/                \|unicodeሴ         \|object \|                        \|  \|1| ).
+    mo_nodes->add( |/unicodeሴ/       \|c                \|num    \|3                       \|  \|0| ).
+    mo_nodes->add( |/                \|quoted"text"     \|object \|                        \|  \|1| ).
+    mo_nodes->add( |/quoted"text"/   \|d                \|num    \|4                       \|  \|0| ).
+    mo_nodes->add( |/                \|line\nfeed       \|object \|                        \|  \|1| ).
+    mo_nodes->add( |/line\nfeed/     \|e                \|num    \|5                       \|  \|0| ).
+    mo_nodes->add( |/                \|with\ttab        \|object \|                        \|  \|1| ).
+    mo_nodes->add( |/with\ttab/      \|f                \|num    \|6                       \|  \|0| ).
+
+    data lt_act type zif_ajson_types=>ty_nodes_tt.
+    data lv_str type string.
+
+    lv_str = '{ "a\\backslash": { "a": 1 }, "contains/slash": { "b": 2 },'
+          && ' "unicode\u1234": { "c": 3 }, "quoted\"text\"": { "d": 4 },'
+          && ' "line\nfeed": { "e": 5 }, "with\ttab": { "f": 6 } }'.
+    lt_act = mo_cut->parse( lv_str ).
+
+    cl_abap_unit_assert=>assert_equals(
+      act = lt_act
+      exp = mo_nodes->mt_nodes ).
+
+  endmethod.
+
+  method special_characters_in_value.
+    mo_nodes->add( |                 \|                 \|object \|                        \|  \|6| ).
+    mo_nodes->add( |/                \|a                \|str    \|a\\backslash            \|  \|0| ).
+    mo_nodes->add( |/                \|b                \|str    \|contains/slash          \|  \|0| ).
+    mo_nodes->add( |/                \|c                \|str    \|unicodeሴ                \|  \|0| ).
+    mo_nodes->add( |/                \|d                \|str    \|quoted"text"            \|  \|0| ).
+    mo_nodes->add( |/                \|e                \|str    \|line\nfeed              \|  \|0| ).
+    mo_nodes->add( |/                \|f                \|str    \|with\ttab               \|  \|0| ).
+
+    data lt_act type zif_ajson_types=>ty_nodes_tt.
+    data lv_str type string.
+
+    lv_str = '{ "a": "a\\backslash", "b": "contains/slash", "c": "unicode\u1234",'
+          && ' "d": "quoted\"text\"", "e": "line\nfeed", "f": "with\ttab" }'.
+    lt_act = mo_cut->parse( lv_str ).
+
+    cl_abap_unit_assert=>assert_equals(
+      act = lt_act
+      exp = mo_nodes->mt_nodes ).
+
+  endmethod.
+
 endclass.
 
 **********************************************************************
@@ -698,6 +774,7 @@ class ltcl_serializer_test implementation.
       it_json_tree = sample_nodes( )
       iv_indent    = 2 ).
     lv_exp = sample_json( ).
+
 
     cl_abap_unit_assert=>assert_equals(
       act = lv_act

--- a/src/core/zcl_ajson.clas.testclasses.abap
+++ b/src/core/zcl_ajson.clas.testclasses.abap
@@ -519,19 +519,21 @@ class ltcl_parser_test implementation.
   endmethod.
 
   method special_characters_in_name.
-    mo_nodes->add( |                 \|                 \|object \|                        \|  \|6| ).
+    mo_nodes->add( |                 \|                 \|object \|                        \|  \|7| ).
     mo_nodes->add( |/                \|a\\backslash     \|num    \|1                       \|  \|0| ).
     mo_nodes->add( |/                \|contains/slash   \|num    \|2                       \|  \|0| ).
     mo_nodes->add( |/                \|unicodeሴ         \|num    \|3                       \|  \|0| ).
     mo_nodes->add( |/                \|quoted"text"     \|num    \|4                       \|  \|0| ).
     mo_nodes->add( |/                \|line\nfeed       \|num    \|5                       \|  \|0| ).
     mo_nodes->add( |/                \|with\ttab        \|num    \|6                       \|  \|0| ).
+    mo_nodes->add( |/                \|one/two/slash    \|num    \|7                       \|  \|0| ).
 
     data lt_act type zif_ajson_types=>ty_nodes_tt.
     data lv_str type string.
 
     lv_str = '{ "a\\backslash": 1, "contains/slash": 2, "unicode\u1234": 3,'
-          && ' "quoted\"text\"": 4, "line\nfeed": 5, "with\ttab": 6 }'.
+          && ' "quoted\"text\"": 4, "line\nfeed": 5, "with\ttab": 6,'
+          && ' "one/two/slash": 7 }'.
     lt_act = mo_cut->parse( lv_str ).
 
     cl_abap_unit_assert=>assert_equals(
@@ -541,7 +543,7 @@ class ltcl_parser_test implementation.
   endmethod.
 
   method special_characters_in_path.
-    mo_nodes->add( |                 \|                 \|object \|                        \|  \|6| ).
+    mo_nodes->add( |                 \|                 \|object \|                        \|  \|7| ).
     mo_nodes->add( |/                \|a\\backslash     \|object \|                        \|  \|1| ).
     mo_nodes->add( |/a\\backslash/   \|a                \|num    \|1                       \|  \|0| ).
     mo_nodes->add( |/                \|contains/slash   \|object \|                        \|  \|1| ).
@@ -554,13 +556,16 @@ class ltcl_parser_test implementation.
     mo_nodes->add( |/line\nfeed/     \|e                \|num    \|5                       \|  \|0| ).
     mo_nodes->add( |/                \|with\ttab        \|object \|                        \|  \|1| ).
     mo_nodes->add( |/with\ttab/      \|f                \|num    \|6                       \|  \|0| ).
+    mo_nodes->add( |/                \|one/two/slash    \|object \|                        \|  \|1| ).
+    mo_nodes->add( |/one\ttwo\tslash/\|g                \|num    \|7                       \|  \|0| ). " tab!
 
     data lt_act type zif_ajson_types=>ty_nodes_tt.
     data lv_str type string.
 
     lv_str = '{ "a\\backslash": { "a": 1 }, "contains/slash": { "b": 2 },'
           && ' "unicode\u1234": { "c": 3 }, "quoted\"text\"": { "d": 4 },'
-          && ' "line\nfeed": { "e": 5 }, "with\ttab": { "f": 6 } }'.
+          && ' "line\nfeed": { "e": 5 }, "with\ttab": { "f": 6 },'
+          && ' "one/two/slash": { "g": 7 } }'.
     lt_act = mo_cut->parse( lv_str ).
 
     cl_abap_unit_assert=>assert_equals(
@@ -570,19 +575,21 @@ class ltcl_parser_test implementation.
   endmethod.
 
   method special_characters_in_value.
-    mo_nodes->add( |                 \|                 \|object \|                        \|  \|6| ).
+    mo_nodes->add( |                 \|                 \|object \|                        \|  \|7| ).
     mo_nodes->add( |/                \|a                \|str    \|a\\backslash            \|  \|0| ).
     mo_nodes->add( |/                \|b                \|str    \|contains/slash          \|  \|0| ).
     mo_nodes->add( |/                \|c                \|str    \|unicodeሴ                \|  \|0| ).
     mo_nodes->add( |/                \|d                \|str    \|quoted"text"            \|  \|0| ).
     mo_nodes->add( |/                \|e                \|str    \|line\nfeed              \|  \|0| ).
     mo_nodes->add( |/                \|f                \|str    \|with\ttab               \|  \|0| ).
+    mo_nodes->add( |/                \|g                \|str    \|one/two/slash           \|  \|0| ).
 
     data lt_act type zif_ajson_types=>ty_nodes_tt.
     data lv_str type string.
 
     lv_str = '{ "a": "a\\backslash", "b": "contains/slash", "c": "unicode\u1234",'
-          && ' "d": "quoted\"text\"", "e": "line\nfeed", "f": "with\ttab" }'.
+          && ' "d": "quoted\"text\"", "e": "line\nfeed", "f": "with\ttab",'
+          && ' "g": "one/two/slash" }'.
     lt_act = mo_cut->parse( lv_str ).
 
     cl_abap_unit_assert=>assert_equals(

--- a/src/perf/zajson_perf_test.prog.abap
+++ b/src/perf/zajson_perf_test.prog.abap
@@ -618,4 +618,18 @@ endclass.
 
 start-of-selection.
 
+  data gv_sta_time type timestampl.
+  data gv_end_time type timestampl.
+  data gv_diff     type timestampl.
+
+  get time stamp field gv_sta_time.
+
   lcl_app=>main( ).
+
+  get time stamp field gv_end_time.
+
+  gv_diff  = cl_abap_tstmp=>subtract(
+    tstmp1 = gv_end_time
+    tstmp2 = gv_sta_time ).
+
+  write: / 'Total runtime:', gv_diff, 'seconds'.


### PR DESCRIPTION
I added tests for handling of special characters - like slashes, quotes, and unicode - in element names, paths, and values. Everything - except of one case - was working but now we know for sure 😃 

The special case is a slash in an element name that has sub-objects: `"contains/slash": "test"` is ok, but `"contains/slash": { "test": 1 }` is not. As suggested in #169, I replaced the slash with a `tab`. Parsing now works well 👍 

For methods that require a path as input, we could either leave it as is and remember to use a tab there, too, or we pre-process the input. 

```abap
* { "contains/slash": { "test": 1 } } or better { "contains\/slash": { "test": 1 } }

r->get( '/contains/slash/test' ). " never worked

r->get( |/contains\tslash/test| ). " works with this PR

r->get( '/contains\/slash/test' ). " could work if the parameter is preprocessed i.e. replace \/ with \t
```

I would go for the middle case and not worry about the parameters. It will be a rare case anyway. 

Closes #169.