### PR TITLE
Add support for timestamps with fractions

### DIFF
--- a/src/core/zcl_ajson.clas.locals_imp.abap
+++ b/src/core/zcl_ajson.clas.locals_imp.abap
@@ -1196,7 +1196,6 @@ class lcl_json_to_abap implementation.
     data lv_date type d.
     data lv_time type t.
     data lv_seconds_conv type i.
-    data lv_frac type p length 10 decimals 6.
     data lv_timestamp type timestampl.
 
     find first occurrence of regex lc_regex_ts_with_hour

--- a/src/core/zcl_ajson.clas.locals_imp.abap
+++ b/src/core/zcl_ajson.clas.locals_imp.abap
@@ -785,6 +785,14 @@ class lcl_json_to_abap definition final.
       raising
         zcx_ajson_error.
 
+    methods to_timestampl
+      importing
+        iv_value         type zif_ajson_types=>ty_node-value
+      returning
+        value(rv_result) type timestampl
+      raising
+        zcx_ajson_error.
+
     methods to_date
       importing
         iv_value         type zif_ajson_types=>ty_node-value
@@ -1120,9 +1128,10 @@ class lcl_json_to_abap implementation.
             <container> = to_date( is_node-value ).
           elseif is_node_type-type_kind = lif_kind=>time.
             <container> = to_time( is_node-value ).
-          elseif is_node_type-dd->absolute_name = '\TYPE=TIMESTAMP'
-            or is_node_type-dd->absolute_name = '\TYPE=TIMESTAMPL'.
+          elseif is_node_type-dd->absolute_name = '\TYPE=TIMESTAMP'.
             <container> = to_timestamp( is_node-value ).
+          elseif is_node_type-dd->absolute_name = '\TYPE=TIMESTAMPL'.
+            <container> = to_timestampl( is_node-value ).
           elseif is_node_type-type_kind = lif_kind=>packed. " Number as a string, but not a timestamp
             <container> = is_node-value.
           else.
@@ -1154,12 +1163,20 @@ class lcl_json_to_abap implementation.
   endmethod.
 
   method to_timestamp.
+    data lv_timestampl type timestampl.
+    lv_timestampl = to_timestampl( iv_value ).
+    if lv_timestampl is not initial.
+      rv_result = cl_abap_tstmp=>move_to_short( lv_timestampl ).
+    endif.
+  endmethod.
+
+  method to_timestampl.
 
     constants lc_utc type c length 6 value 'UTC'.
     constants lc_regex_ts_with_hour type string
       value `^(\d{4})-(\d{2})-(\d{2})(T)(\d{2}):(\d{2}):(\d{2})(\+)(\d{2}):(\d{2})`. "#EC NOTEXT
     constants lc_regex_ts_utc type string
-      value `^(\d{4})-(\d{2})-(\d{2})(T)(\d{2}):(\d{2}):(\d{2})(Z|$)`. "#EC NOTEXT
+      value `^(\d{4})-(\d{2})-(\d{2})(T)(\d{2}):(\d{2}):(\d{2})(\.\d+)?(Z|$)`. "#EC NOTEXT
 
     data:
       begin of ls_timestamp,
@@ -1170,6 +1187,7 @@ class lcl_json_to_abap implementation.
         hour         type c length 2,
         minute       type c length 2,
         second       type c length 2,
+        frac         type c length 8,
         local_sign   type c length 1,
         local_hour   type c length 2,
         local_minute type c length 2,
@@ -1178,6 +1196,7 @@ class lcl_json_to_abap implementation.
     data lv_date type d.
     data lv_time type t.
     data lv_seconds_conv type i.
+    data lv_frac type p length 10 decimals 6.
     data lv_timestamp type timestampl.
 
     find first occurrence of regex lc_regex_ts_with_hour
@@ -1195,7 +1214,7 @@ class lcl_json_to_abap implementation.
       find first occurrence of regex lc_regex_ts_utc
         in iv_value submatches
           ls_timestamp-year ls_timestamp-month ls_timestamp-day ls_timestamp-t
-          ls_timestamp-hour ls_timestamp-minute ls_timestamp-second.
+          ls_timestamp-hour ls_timestamp-minute ls_timestamp-second ls_timestamp-frac.
 
       if sy-subrc <> 0.
         zcx_ajson_error=>raise( 'Unexpected timestamp format' ).
@@ -1207,6 +1226,12 @@ class lcl_json_to_abap implementation.
     concatenate ls_timestamp-hour ls_timestamp-minute ls_timestamp-second into lv_time.
 
     convert date lv_date time lv_time into time stamp lv_timestamp time zone lc_utc.
+
+    " add fraction
+    if ls_timestamp-frac is not initial.
+      ls_timestamp-frac = '0' && ls_timestamp-frac.
+      lv_timestamp = lv_timestamp + ls_timestamp-frac.
+    endif.
 
     try.
 

--- a/src/core/zcl_ajson.clas.testclasses.abap
+++ b/src/core/zcl_ajson.clas.testclasses.abap
@@ -1602,6 +1602,7 @@ class ltcl_json_to_abap definition
         timestamp2 type timestamp,
         timestamp3 type timestamp,
         timestamp4 type timestampl,
+        timestamp5 type timestampl,
       end of ty_complex.
 
     methods to_abap_struc
@@ -1703,6 +1704,7 @@ class ltcl_json_to_abap implementation.
     lo_nodes->add( '/      |timestamp2 |str    |2020-07-28T00:00:00Z      | ' ).
     lo_nodes->add( '/      |timestamp3 |str    |2020-07-28T01:00:00+01:00 | ' ).
     lo_nodes->add( '/      |timestamp4 |str    |2020-07-28T01:00:00+01:00 | ' ).
+    lo_nodes->add( '/      |timestamp5 |str    |2020-07-28T00:00:00.12345Z| ' ).
 
     create object lo_cut.
     lo_cut->to_abap(
@@ -1722,6 +1724,7 @@ class ltcl_json_to_abap implementation.
     ls_exp-timestamp2 = lv_exp_timestamp.
     ls_exp-timestamp3 = lv_exp_timestamp.
     ls_exp-timestamp4 = lv_exp_timestamp.
+    ls_exp-timestamp5 = lv_exp_timestamp + '0.12345'.
 
     cl_abap_unit_assert=>assert_equals(
       act = ls_mock


### PR DESCRIPTION
Fields with `timestampl` data element are now filled correctly.

Example: `2020-07-28T00:00:00.12345Z`