### PR TITLE
Fix for long timestamps and utclong

### DIFF
--- a/src/core/zcl_ajson.clas.locals_imp.abap
+++ b/src/core/zcl_ajson.clas.locals_imp.abap
@@ -28,6 +28,7 @@ interface lif_kind.
       packed     type ty_kind value cl_abap_typedescr=>typekind_packed,
       decfloat16 type ty_kind value cl_abap_typedescr=>typekind_decfloat16,
       decfloat34 type ty_kind value cl_abap_typedescr=>typekind_decfloat34,
+      utclong    type ty_kind value 'p', " cl_abap_typedescr=>typekind_utclong not in lower releases,
     end of numeric.
 
   constants:
@@ -1646,6 +1647,9 @@ class lcl_abap_to_json implementation.
     split |{ iv_ts }| at '.' into lv_int lv_frac.
     shift lv_frac right deleting trailing '0'.
     shift lv_frac left deleting leading space.
+    if lv_frac is initial.
+      lv_frac = '0'.
+    endif.
 
     rv_str =
       lv_date+0(4) && '-' && lv_date+4(2) && '-' && lv_date+6(2) &&
@@ -1684,6 +1688,14 @@ class lcl_abap_to_json implementation.
       if mv_format_datetime = abap_true.
         ls_node-type  = zif_ajson_types=>node_type-string.
         ls_node-value = format_timestamp( iv_data ).
+      else.
+        ls_node-type  = zif_ajson_types=>node_type-number.
+        ls_node-value = |{ iv_data }|.
+      endif.
+    elseif io_type->absolute_name = '\TYPE=TIMESTAMPL'.
+      if mv_format_datetime = abap_true.
+        ls_node-type  = zif_ajson_types=>node_type-string.
+        ls_node-value = format_timestampl( iv_data ).
       else.
         ls_node-type  = zif_ajson_types=>node_type-number.
         ls_node-value = |{ iv_data }|.

--- a/src/core/zcl_ajson.clas.testclasses.abap
+++ b/src/core/zcl_ajson.clas.testclasses.abap
@@ -4451,6 +4451,8 @@ class ltcl_abap_to_json definition
     methods set_value_xsdboolean for testing raising zcx_ajson_error.
     methods set_value_timestamp for testing raising zcx_ajson_error.
     methods set_value_timestamp_initial for testing raising zcx_ajson_error.
+    methods set_value_timestampl for testing raising zcx_ajson_error.
+    methods set_value_timestampl_initial for testing raising zcx_ajson_error.
     methods set_null for testing raising zcx_ajson_error.
     methods set_obj for testing raising zcx_ajson_error.
     methods set_array for testing raising zcx_ajson_error.
@@ -4621,6 +4623,45 @@ class ltcl_abap_to_json implementation.
 
     lv_timestamp = 0.
     lt_nodes = lcl_abap_to_json=>convert( lcl_abap_to_json=>format_timestamp( lv_timestamp ) ).
+
+    cl_abap_unit_assert=>assert_equals(
+      act = lt_nodes
+      exp = lo_nodes_exp->mt_nodes ).
+
+  endmethod.
+
+  method set_value_timestampl.
+
+    data lo_nodes_exp type ref to lcl_nodes_helper.
+    data lt_nodes type zif_ajson_types=>ty_nodes_tt.
+    data lv_timezone type timezone value ''.
+
+    data lv_timestampl type timestampl.
+    create object lo_nodes_exp.
+    lo_nodes_exp->add( '        |      |str |2022-08-31T12:34:56.1234567Z||' ).
+
+    convert date '20220831' time '123456'
+      into time stamp lv_timestampl time zone lv_timezone.
+    lv_timestampl = lv_timestampl + '0.1234567'.
+    lt_nodes = lcl_abap_to_json=>convert( lcl_abap_to_json=>format_timestampl( lv_timestampl ) ).
+
+    cl_abap_unit_assert=>assert_equals(
+      act = lt_nodes
+      exp = lo_nodes_exp->mt_nodes ).
+
+  endmethod.
+
+  method set_value_timestampl_initial.
+
+    data lo_nodes_exp type ref to lcl_nodes_helper.
+    data lt_nodes type zif_ajson_types=>ty_nodes_tt.
+
+    data lv_timestampl type timestampl.
+    create object lo_nodes_exp.
+    lo_nodes_exp->add( '        |      |str |0000-00-00T00:00:00.0Z||' ).
+
+    lv_timestampl = 0.
+    lt_nodes = lcl_abap_to_json=>convert( lcl_abap_to_json=>format_timestampl( lv_timestampl ) ).
 
     cl_abap_unit_assert=>assert_equals(
       act = lt_nodes


### PR DESCRIPTION
Long timestamps (data element `timestampl`) were not detected correctly, and fields of type `utclong` (new releases) would lead to error `Unexpected elementary type [p]` (example, table `adrc-addresscreatedondatetime`).

Also fixed an issue with initial long timestamps. 

PS: No tests for `utclong` since it would not work on lower releases.