### PR TITLE
docs: slash in attributes

### DIFF
--- a/docsite/docs/30-basics.md
+++ b/docsite/docs/30-basics.md
@@ -12,12 +12,8 @@ sidebar_position: 30
 
 - All functional methods and types are defined in `zif_ajson` interface.
   - Methods have aliases in the `zcl_ajson` class, however please restrain from using them directly as they may be *deprecated* in future.
-- Json attributes are addressed by path in form `/obj1/obj2/value` of e.g. `->get( '/a/b/c' )` addresses `{ "a": { "b": { "c": "this value !" } } }`
+- JSON attributes are addressed by path in form `/obj1/obj2/value` of e.g. `get( '/a/b/c' )` addresses `{ "a": { "b": { "c": "this value !" } } }`. If an attribute contains slashes, for example in `{ "a/b/c": 10 }`, you have to replace the slashes with tabs (`\t`) to access the value e.g., `get( |/a\tb\tc| )`.
 - Array items addressed with index starting from 1: `/tab/2/val` -> `{ "tab": [ {...}, { "val": "this value !" } ] }`
-
-## Support for '/' in attribute names
-
-*TBD*
 
 ## Chaining
 


### PR DESCRIPTION
Very nice doc site! You should add the link to the repo meta here:

<img width="428" height="199" alt="image" src="https://github.com/user-attachments/assets/01e47004-ae22-4712-ab31-f0888ae2f353" />

Ref #203

PS: `ajson.org` or `ajson.dev` ares available. 
